### PR TITLE
fix: GitHub Actions用のArgoCD RBACポリシーから同期拒否ルールを削除

### DIFF
--- a/argoproj/argocd/overlays/argocd-rbac-cm.yaml
+++ b/argoproj/argocd/overlays/argocd-rbac-cm.yaml
@@ -10,5 +10,4 @@ data:
     # GitHub Actions用アカウントに対するポリシー設定
     # アプリケーションの参照のみ許可し、同期権限は明示的に拒否
     p, role:github-actions, applications, get, */*, allow
-    p, role:github-actions, applications, sync, */*, deny
     g, github-actions, role:github-actions 


### PR DESCRIPTION
GitHub Actionsロールの同期権限に関する制限を緩和し、より柔軟なアクセス制御を実現