### PR TITLE
Change update strategy to Recreate for openhands Deployment

### DIFF
--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: openhands
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
+
   selector:
     matchLabels:
       app: openhands


### PR DESCRIPTION
This change updates the deployment strategy for openhands to Recreate in order to avoid port conflicts when using hostNetwork.