### PR TITLE
Add ignoreDifferences to Application manifest for PVC

### DIFF
--- a/argoproj/openhands/application.yaml
+++ b/argoproj/openhands/application.yaml
@@ -12,6 +12,12 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: openhands
+  ignoreDifferences:
+    - group: ""
+      kind: PersistentVolumeClaim
+      jsonPointers:
+        - /spec/volumeName
+
   syncPolicy:
     syncOptions:
       - CreateNamespace=true

--- a/argoproj/openhands/pvc.yaml
+++ b/argoproj/openhands/pvc.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  volumeName: pvc-eb52942a-3f20-447a-9b53-aeb761bcd491
   storageClassName: longhorn
   resources:
     requests:
@@ -21,6 +22,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: longhorn
+  volumeName: pvc-3359e2f7-f977-49bd-aa03-ebb43d184f0b
   resources:
     requests:
       storage: 5Gi 

--- a/argoproj/openhands/pvc.yaml
+++ b/argoproj/openhands/pvc.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  volumeName: pvc-eb52942a-3f20-447a-9b53-aeb761bcd491
   storageClassName: longhorn
   resources:
     requests:
@@ -22,7 +21,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: longhorn
-  volumeName: pvc-3359e2f7-f977-49bd-aa03-ebb43d184f0b
   resources:
     requests:
       storage: 5Gi 


### PR DESCRIPTION
This change adds ignoreDifferences settings for PersistentVolumeClaim to ignore changes of the volumeName field, which is immutable after creation.