### PR TITLE
Remove Replace sync option from Application manifest to avoid immutable PVC updates

### DIFF
--- a/argoproj/openhands/application.yaml
+++ b/argoproj/openhands/application.yaml
@@ -21,7 +21,6 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-      - Replace=true
       - ServerSideApply=true 
     automated:
       prune: true


### PR DESCRIPTION
Removing Replace from syncOptions to use server-side apply (patch) rather than full replace, avoiding immutable field violations on PVCs.