### PR TITLE
Renovateの設定を改善してdocker.all-hands.dev/all-hands-ai/runtimeイメージを更新対象に追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,11 +18,22 @@
       "customType": "regex",
       "fileMatch": ["\\.yaml$"] ,
       "matchStrings": [
-        "image:\\s*docker.all-hands.dev/all-hands-ai/[^:\\s]+:(?<version>[\\w.-]+)",
-        "value:\\s*docker.all-hands.dev/all-hands-ai/[^:\\s]+:(?<version>[\\w.-]+)"
+        "image:\\s*docker.all-hands.dev/all-hands-ai/([^:\\s]+):(?<version>[\\w.-]+(?:-[\\w]+)?)",
+        "value:\\s*docker.all-hands.dev/all-hands-ai/([^:\\s]+):(?<version>[\\w.-]+(?:-[\\w]+)?)"
       ],
       "datasourceTemplate": "docker",
-      "depNameTemplate": "docker.all-hands.dev/all-hands-ai",
+      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/$1",
+      "versioningTemplate": "docker",
+      "currentValueTemplate": "{{currentValue}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.yaml$"],
+      "matchStrings": [
+        "value:\\s*docker.all-hands.dev/all-hands-ai/runtime:(?<version>[\\w.-]+(?:-nikolaik)?)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/runtime",
       "versioningTemplate": "docker",
       "currentValueTemplate": "{{currentValue}}"
     }


### PR DESCRIPTION
## 変更内容

Renovateの設定を改善して、`docker.all-hands.dev/all-hands-ai/runtime:0.27-nikolaik`イメージを更新対象に追加しました。

### 主な変更点

1. 一般的なdocker.all-hands.devイメージの検出パターンを改善
   - イメージ名を捕捉グループとして取得
   - depNameTemplateでイメージ名を含めるように変更
   - バージョン部分の正規表現を拡張して、ハイフン付きの接尾辞も認識できるように

2. 特定のruntimeイメージ用の専用パターンを追加
   - `docker.all-hands.dev/all-hands-ai/runtime:0.27-nikolaik`のような特定パターンに対応
   - 明示的なdepNameTemplateを設定

これらの変更により、環境変数として設定されているdocker.all-hands.dev/all-hands-ai/runtimeイメージも、Renovateの更新対象として正しく認識されるようになります。