### PR TITLE
Renovate設定をさらに改善し、OpenHands関連のルールを具体化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,10 +15,23 @@
       "currentValueTemplate": "{{currentValue}}"
     },
     {
+      "description": "OpenHands container image",
       "customType": "regex",
-      "fileMatch": ["\\.yaml$"],
+      "fileMatch": ["argoproj/openhands/.*\\.yaml$"],
       "matchStrings": [
-        "value:\\s*docker.all-hands.dev/all-hands-ai/runtime:(?<version>[\\w.-]+(?:-nikolaik)?)"
+        "image:\\s*docker\\.all-hands\\.dev/all-hands-ai/openhands:(?<version>[\\w.-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/openhands",
+      "versioningTemplate": "docker",
+      "currentValueTemplate": "{{currentValue}}"
+    },
+    {
+      "description": "OpenHands runtime container image in environment variable",
+      "customType": "regex",
+      "fileMatch": ["argoproj/openhands/.*\\.yaml$"],
+      "matchStrings": [
+        "name:\\s*SANDBOX_RUNTIME_CONTAINER_IMAGE[\\s\\S]*?value:\\s*docker\\.all-hands\\.dev/all-hands-ai/runtime:(?<version>[\\w.-]+(?:-nikolaik)?)"
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "docker.all-hands.dev/all-hands-ai/runtime",
@@ -26,6 +39,7 @@
       "currentValueTemplate": "{{currentValue}}"
     },
     {
+      "description": "General docker.all-hands.dev images in image: field",
       "customType": "regex",
       "fileMatch": ["\\.yaml$"],
       "matchStrings": [
@@ -37,6 +51,7 @@
       "currentValueTemplate": "{{currentValue}}"
     },
     {
+      "description": "General docker.all-hands.dev images in value: field",
       "customType": "regex",
       "fileMatch": ["\\.yaml$"],
       "matchStrings": [


### PR DESCRIPTION
## 変更内容

Renovateの設定をさらに改善し、OpenHands関連のルールをより具体的にしました。

### 主な変更点

1. 各ルールに説明（description）を追加して可読性を向上

2. OpenHands関連のルールをより具体的に設定
   - ファイルパスを `argoproj/openhands/` ディレクトリに限定
   - 環境変数名 `SANDBOX_RUNTIME_CONTAINER_IMAGE` を含めたより具体的なパターンマッチング

3. 一般的なdocker.all-hands.devイメージ用のルールも維持
   - 他のディレクトリにある可能性のあるイメージにも対応

これらの変更により、特に環境変数として設定されている `docker.all-hands.dev/all-hands-ai/runtime:0.27-nikolaik` イメージが確実にRenovateの更新対象として認識されるようになります。