### PR TITLE
OpenHandsのコンテナに関するRenovate設定を削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,74 +13,10 @@
       "depNameTemplate": "docker.io/cloudflare/cloudflared",
       "versioningTemplate": "docker",
       "currentValueTemplate": "{{currentValue}}"
-    },
-    {
-      "description": "OpenHands container image",
-      "customType": "regex",
-      "fileMatch": ["argoproj/openhands/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*docker\\.all-hands\\.dev/all-hands-ai/openhands:(?<version>[\\w.-]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/openhands",
-      "versioningTemplate": "docker",
-      "currentValueTemplate": "{{currentValue}}"
-    },
-    {
-      "description": "OpenHands runtime container image in environment variable",
-      "customType": "regex",
-      "fileMatch": ["argoproj/openhands/.*\\.yaml$"],
-      "matchStrings": [
-        "value:\\s*docker\\.all-hands\\.dev/all-hands-ai/runtime:(?<version>[\\w.-]+(?:-nikolaik)?)"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/runtime",
-      "versioningTemplate": "docker",
-      "currentValueTemplate": "{{currentValue}}"
-    },
-    {
-      "description": "General docker.all-hands.dev images in image: field",
-      "customType": "regex",
-      "fileMatch": ["\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*docker.all-hands.dev/all-hands-ai/([^:\\s]+):(?<version>[\\w.-]+(?:-[\\w]+)?)"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/$1",
-      "versioningTemplate": "docker",
-      "currentValueTemplate": "{{currentValue}}"
-    },
-    {
-      "description": "General docker.all-hands.dev images in value: field",
-      "customType": "regex",
-      "fileMatch": ["\\.yaml$"],
-      "matchStrings": [
-        "value:\\s*docker\\.all-hands\\.dev/all-hands-ai/([^:\\s]+):(?<version>[\\w.-]+(?:-[\\w]+)?)"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/$1",
-      "versioningTemplate": "docker",
-      "currentValueTemplate": "{{currentValue}}"
-    },
-    {
-      "description": "Specific runtime image with nikolaik tag",
-      "customType": "regex",
-      "fileMatch": ["argoproj/openhands/deployment.yaml"],
-      "matchStrings": [
-        "SANDBOX_RUNTIME_CONTAINER_IMAGE[\\s\\S]*?value:\\s*docker\\.all-hands\\.dev/all-hands-ai/runtime:(?<currentValue>[\\d.]+)-nikolaik"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "docker.all-hands.dev/all-hands-ai/runtime",
-      "versioningTemplate": "docker"
     }
+
   ],
   "major": { "automerge": false },
   "automerge": true,
-  "platformAutomerge": true,
-  "hostRules": [
-    {
-      "matchHost": "docker.all-hands.dev",
-      "hostType": "docker"
-    }
-  ]
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## 概要
OpenHandsのコンテナに関するRenovate設定を全て削除しました。

## 変更内容
- docker.all-hands.dev/all-hands-ai/openhandsイメージの更新設定を削除
- docker.all-hands.dev/all-hands-ai/runtimeイメージの更新設定を削除
- docker.all-hands.devに関する一般的な設定を削除
- hostRulesからdocker.all-hands.devの設定を削除