### PR TITLE
AWS キー名の更新: bedrock から parameter-reader へ

### DIFF
--- a/argoproj/openhands/external-secret.yaml
+++ b/argoproj/openhands/external-secret.yaml
@@ -14,8 +14,8 @@ spec:
   data:
   - secretKey: tunnel-token
     remoteRef:
-      conversionStrategy: Default	
-      decodingStrategy: None	
+      conversionStrategy: Default       
+      decodingStrategy: None    
       key: openhands-tunnel-token
       metadataPolicy: None 
 ---
@@ -37,11 +37,11 @@ spec:
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: bedrock-access-key-id
+      key: parameter-reader-access-key-id
       metadataPolicy: None
   - secretKey: AWS_SECRET_ACCESS_KEY
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: bedrock-secret-access-key
+      key: parameter-reader-secret-access-key
       metadataPolicy: None 


### PR DESCRIPTION
このPRでは、openhandsで使用されているAWS キーの名前を変更しています。

## 変更内容

- `bedrock-access-key-id` → `parameter-reader-access-key-id`
- `bedrock-secret-access-key` → `parameter-reader-secret-access-key`

これにより、AWS キーの名前変更に対応し、openhandsが正常に動作するようになります。