### PR TITLE
認証情報名の更新: bedrock から parameter-reader へ

### DIFF
--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -32,16 +32,16 @@ spec:
         # kubectl get nodes golyat-1 -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}'
         - name: WORKSPACE_MOUNT_PATH
           value: /opt/workspace_base
-        # AWS Bedrock関連の環境変数
+        # AWS Parameter Reader関連の環境変数
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              name: bedrock-credentials
+              name: parameter-reader-credentials
               key: AWS_ACCESS_KEY_ID
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: bedrock-credentials
+              name: parameter-reader-credentials
               key: AWS_SECRET_ACCESS_KEY
         - name: AWS_REGION
           value: "us-west-2"

--- a/argoproj/openhands/external-secret.yaml
+++ b/argoproj/openhands/external-secret.yaml
@@ -22,7 +22,7 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: bedrock-credentials
+  name: parameter-reader-credentials
   namespace: openhands
 spec:
   refreshInterval: 1h
@@ -30,7 +30,7 @@ spec:
     name: parameterstore
     kind: ClusterSecretStore
   target:
-    name: bedrock-credentials
+    name: parameter-reader-credentials
     creationPolicy: Owner
   data:
   - secretKey: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
このPRでは、openhandsで使用されている認証情報の名前を変更しています。

## 変更内容

- ExternalSecret名: `bedrock-credentials` → `parameter-reader-credentials`
- Secret名: `bedrock-credentials` → `parameter-reader-credentials`
- コメント: AWS Bedrock関連 → AWS Parameter Reader関連

これにより、AWS キーの名前変更に合わせて、関連する認証情報の名前も統一されます。