### PR TITLE
ECRトークンアップデーターを動的なnamespace処理に対応

### DIFF
--- a/argoproj/k8s-ecr-token-updater/cronjob.yaml
+++ b/argoproj/k8s-ecr-token-updater/cronjob.yaml
@@ -26,11 +26,21 @@ spec:
               - -c
               - |-
                 ECR_TOKEN="$(aws ecr get-login-password --region ${AWS_REGION})"
-                for val in palserver argocd stage-hitohub prod-hitohub
+                # システム用の除外namespaceリスト（必要に応じて調整）
+                EXCLUDE_NAMESPACES="kube-public kube-node-lease default"
+                
+                echo "Starting ECR credential update for all namespaces..."
+                for NAMESPACE_NAME in $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
                 do
-                NAMESPACE_NAME=$val
-                kubectl delete secret --ignore-not-found $DOCKER_SECRET_NAME -n $NAMESPACE_NAME
-                kubectl create secret docker-registry $DOCKER_SECRET_NAME --docker-server=https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com --docker-username=AWS --docker-password=${ECR_TOKEN} --namespace=$NAMESPACE_NAME
+                  # 除外リストにあるnamespaceはスキップ
+                  if echo "$EXCLUDE_NAMESPACES" | grep -qw "$NAMESPACE_NAME"; then
+                    echo "Skipping system namespace: $NAMESPACE_NAME"
+                    continue
+                  fi
+                  
+                  echo "Updating ECR credentials for namespace: $NAMESPACE_NAME"
+                  kubectl delete secret --ignore-not-found $DOCKER_SECRET_NAME -n $NAMESPACE_NAME
+                  kubectl create secret docker-registry $DOCKER_SECRET_NAME --docker-server=https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com --docker-username=AWS --docker-password=${ECR_TOKEN} --namespace=$NAMESPACE_NAME
                 done
-                echo "Secret was successfully updated at $(date)"
+                echo "Secret was successfully updated for all namespaces at $(date)"
           restartPolicy: Never

--- a/argoproj/k8s-ecr-token-updater/cronjob.yaml
+++ b/argoproj/k8s-ecr-token-updater/cronjob.yaml
@@ -26,8 +26,8 @@ spec:
               - -c
               - |-
                 ECR_TOKEN="$(aws ecr get-login-password --region ${AWS_REGION})"
-                # システム用の除外namespaceリスト（必要に応じて調整）
-                EXCLUDE_NAMESPACES="kube-public kube-node-lease default"
+                # 除外するnamespaceリスト
+                EXCLUDE_NAMESPACES="default tigera-operator tidb-admin reloader observation monitoring longhorn-system kube-system kube-public kube-node-lease k8s-ecr-token-updater k8s-dashboard external-secrets calico-system calico-apiserver"
                 
                 echo "Starting ECR credential update for all namespaces..."
                 for NAMESPACE_NAME in $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')


### PR DESCRIPTION
## 変更内容

ECRトークンアップデーターのCronJobを修正し、クラスターの状態に合わせて自動的にすべてのnamespaceのcredentialを更新するようにしました。

### 主な変更点

- ハードコードされていたnamespaceリストを削除
- `kubectl get namespaces`コマンドを使用して動的にnamespaceを取得
- 特定のシステムnamespace（kube-public, kube-node-lease, default）を除外するロジックを追加
- ログ出力を強化して処理状況を確認しやすく改善

この変更により、新しいnamespaceが追加された場合でも手動での設定変更が不要になります。