### PR TITLE
ECRトークンアップデーターにnamespace一覧取得権限を追加

### DIFF
--- a/argoproj/k8s-ecr-token-updater/cluster-role.yaml
+++ b/argoproj/k8s-ecr-token-updater/cluster-role.yaml
@@ -10,6 +10,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/argoproj/k8s-ecr-token-updater/cronjob.yaml
+++ b/argoproj/k8s-ecr-token-updater/cronjob.yaml
@@ -25,12 +25,27 @@ spec:
               - /bin/bash
               - -c
               - |-
+                echo "Starting ECR credential update for all namespaces..."
                 ECR_TOKEN="$(aws ecr get-login-password --region ${AWS_REGION})"
-                for val in palserver argocd stage-hitohub prod-hitohub
+                
+                # 除外するnamespaceのリスト
+                EXCLUDED_NAMESPACES="default tigera-operator tidb-admin reloader observation monitoring longhorn-system kube-system kube-public kube-node-lease k8s-ecr-token-updater k8s-dashboard external-secrets calico-system calico-apiserver"
+                
+                # すべてのnamespaceを取得
+                NAMESPACES=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
+                
+                for NAMESPACE_NAME in $NAMESPACES
                 do
-                NAMESPACE_NAME=$val
-                kubectl delete secret --ignore-not-found $DOCKER_SECRET_NAME -n $NAMESPACE_NAME
-                kubectl create secret docker-registry $DOCKER_SECRET_NAME --docker-server=https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com --docker-username=AWS --docker-password=${ECR_TOKEN} --namespace=$NAMESPACE_NAME
+                  # 除外リストにnamespaceが含まれているかチェック
+                  if [[ $EXCLUDED_NAMESPACES =~ (^|[[:space:]])$NAMESPACE_NAME($|[[:space:]]) ]]; then
+                    echo "Skipping excluded namespace: $NAMESPACE_NAME"
+                    continue
+                  fi
+                  
+                  echo "Updating ECR credentials for namespace: $NAMESPACE_NAME"
+                  kubectl delete secret --ignore-not-found $DOCKER_SECRET_NAME -n $NAMESPACE_NAME
+                  kubectl create secret docker-registry $DOCKER_SECRET_NAME --docker-server=https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com --docker-username=AWS --docker-password=${ECR_TOKEN} --namespace=$NAMESPACE_NAME
                 done
-                echo "Secret was successfully updated at $(date)"
+                
+                echo "Secret was successfully updated for all namespaces at $(date)"
           restartPolicy: Never


### PR DESCRIPTION
## 変更内容

- ServiceAccountにnamespaceリソースへのlist/get権限を追加
- cronjob.yamlを修正して動的にすべてのnamespaceを取得するように変更
- 除外するnamespaceリストを明示的に定義

## 修正理由

ECRトークンアップデーターがnamespaceリソースにアクセスできず、エラーが発生していました：
```
Starting ECR credential update for all namespaces...
Error from server (Forbidden): namespaces is forbidden: User "system:serviceaccount:k8s-ecr-token-updater:sa-default" cannot list resource "namespaces" in API group "" at the cluster scope
```

この修正により、ServiceAccountに適切な権限を付与し、すべての必要なnamespaceにECRトークンを更新できるようになります。