### PR TITLE
ServiceAccountにnamespace一覧取得権限を追加

### DIFF
--- a/argoproj/k8s-ecr-token-updater/cluster-role.yaml
+++ b/argoproj/k8s-ecr-token-updater/cluster-role.yaml
@@ -10,6 +10,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## 変更内容

- ServiceAccountにnamespaceリソースへのlist/get権限を追加

## 修正理由

ECRトークンアップデーターがnamespaceリソースにアクセスできず、エラーが発生していました：
```
Starting ECR credential update for all namespaces...
Error from server (Forbidden): namespaces is forbidden: User "system:serviceaccount:k8s-ecr-token-updater:sa-default" cannot list resource "namespaces" in API group "" at the cluster scope
```

この修正により、ServiceAccountに適切な権限を付与し、すべての必要なnamespaceにECRトークンを更新できるようになります。

注：cronjob.yamlはすでにmainブランチで修正されているため、このPRではcluster-role.yamlの変更のみを含んでいます。