### PR TITLE
OpenHandsのバージョンを0.26に下げてrenovateの更新対象から除外

### DIFF
--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
       - name: openhands
-        image: docker.all-hands.dev/all-hands-ai/openhands:0.28
+        image: docker.all-hands.dev/all-hands-ai/openhands:0.26
         ports:
         - containerPort: 3000
         env:

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,12 @@
       "versioningTemplate": "docker",
       "currentValueTemplate": "{{currentValue}}"
     }
-
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["docker.all-hands.dev/all-hands-ai/openhands"],
+      "enabled": false
+    }
   ],
   "major": { "automerge": false },
   "automerge": true,


### PR DESCRIPTION
このPRでは以下の変更を行っています：

1. OpenHandsのバージョンを0.28から0.26に下げました
2. renovate.jsonにpackageRulesを追加し、OpenHandsを自動更新の対象から除外しました