### PR TITLE
OpenHandsのバージョンを0.29.1に更新

### DIFF
--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - containerPort: 3000
         env:
         - name: SANDBOX_RUNTIME_CONTAINER_IMAGE
-          value: docker.all-hands.dev/all-hands-ai/runtime:0.27-nikolaik
+          value: docker.all-hands.dev/all-hands-ai/runtime:0.29.1-nikolaik
         - name: SANDBOX_LOCAL_RUNTIME_URL
           value: http://127.0.0.1
         # 注意: このIPアドレスは実際のgolyat-1ノードのIPアドレスに置き換えてください

--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
       - name: openhands
-        image: docker.all-hands.dev/all-hands-ai/openhands:0.26
+        image: docker.all-hands.dev/all-hands-ai/openhands:0.29.1
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
OpenHandsのバージョンを0.28から0.29.1に更新しました。

## 変更内容
- argoproj/openhands/deployment.yamlのOpenHandsイメージタグを0.29.1に更新
- runtime containerのバージョンも0.27-nikolaikから0.29.1-nikolaikに更新
- mainブランチとのマージコンフリクトを解消