### PR TITLE
ecr-auth-cronjob.yamlにおいて、boxpユーザーのUID/GIDを固定値（1000:1000）に変更し、/etcディレ…

### DIFF
--- a/argoproj/openhands/ecr-auth-cronjob.yaml
+++ b/argoproj/openhands/ecr-auth-cronjob.yaml
@@ -49,22 +49,16 @@ spec:
                   # 認証情報ファイルをコピー
                   cp -f /root/.docker/config.json /host-docker/config.json
                   
-                  # boxpユーザーのUID/GIDを取得（ホストから）
-                  BOXP_UID=$(grep boxp /etc/passwd | cut -d: -f3)
-                  BOXP_GID=$(grep boxp /etc/passwd | cut -d: -f4)
-                  
-                  # UIDが見つからない場合は一般的なユーザーのUID/GIDを使用
-                  if [ -z "$BOXP_UID" ]; then
-                    BOXP_UID=1000
-                    BOXP_GID=1000
-                  fi
+                  # 固定UID/GID（boxpユーザー用）
+                  BOXP_UID=1000
+                  BOXP_GID=1000
                   
                   # 所有権を変更
                   chown ${BOXP_UID}:${BOXP_GID} /host-docker/config.json
                   # パーミッションを設定（ユーザーのみ読み書き可能）
                   chmod 600 /host-docker/config.json
                   
-                  echo "ホスト側の認証情報ファイルを更新し、権限を設定しました: /home/boxp/.docker/config.json (${BOXP_UID}:${BOXP_GID})"
+                  echo "ホスト側の認証情報ファイルを更新し、権限を設定しました: /home/boxp/.docker/config.json (1000:1000)"
                 fi
                 
                 echo "OpenHands ホストECR認証情報の更新が完了しました"
@@ -85,9 +79,6 @@ spec:
               mountPath: /var/run/docker.sock
             - name: host-docker-config
               mountPath: /host-docker
-            - name: host-etc
-              mountPath: /etc
-              readOnly: true
           volumes:
           - name: docker-sock
             hostPath:
@@ -96,9 +87,5 @@ spec:
           - name: host-docker-config
             hostPath:
               path: /home/boxp/.docker
-              type: Directory
-          - name: host-etc
-            hostPath:
-              path: /etc
               type: Directory
           restartPolicy: OnFailure 


### PR DESCRIPTION
…クトリのマウント設定を削除しました。また、認証情報ファイルの更新メッセージを修正しました。