### PR TITLE
Update OpenHands image to dev version 4ec16f3c

### DIFF
--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
       - name: openhands
-        image: docker.all-hands.dev/all-hands-ai/openhands:0.32.0
+        image: docker.all-hands.dev/all-hands-ai/openhands:4ec16f3c2ef76865e64cec10a949ccbf92e542e1
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
loliceクラスター上で動作しているopenhandsのバージョンを `4ec16f3c2ef76865e64cec10a949ccbf92e542e1` に更新します。