### PR TITLE
feat: Enable Longhorn ServiceMonitor for Prometheus metrics

### DIFF
--- a/argoproj/longhorn/application.yaml
+++ b/argoproj/longhorn/application.yaml
@@ -14,6 +14,9 @@ spec:
           preUpgradeChecker:
             jobEnabled: false
           defaultSettings.defaultReplicaCount: 2
+          metrics:
+            serviceMonitor:
+              enabled: true
     - path: argoproj/longhorn
       repoURL: https://github.com/boxp/lolice
       targetRevision: main


### PR DESCRIPTION
Prometheus が Longhorn のメトリクスを収集できるように、Longhorn の Helm Chart で ServiceMonitor の作成を有効にします。\n\n## 変更内容\n\n- `argoproj/longhorn/application.yaml` の `helm.values` に `metrics.serviceMonitor.enabled: true` を追加しました。