### PR TITLE
cloudflaredのデプロイメント設定を更新。自動更新を無効化し、ログレベルをデバッグに設定。Readiness Probeの設定を強…

### DIFF
--- a/argoproj/boxp-home/cloudflared-deployment.yaml
+++ b/argoproj/boxp-home/cloudflared-deployment.yaml
@@ -22,8 +22,11 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
+        - --no-autoupdate
         - --metrics
         - 0.0.0.0:2000
+        - --loglevel
+        - debug
         - run
         - --token
         - $(TUNNEL_TOKEN)
@@ -31,9 +34,18 @@ spec:
           httpGet:
             path: /ready
             port: 2000
-          failureThreshold: 1
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 2000
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 5
         env:
           - name: TUNNEL_TOKEN
             valueFrom:


### PR DESCRIPTION
…化し、初期遅延や周期を調整。