### PR TITLE
feat: OpenHandsを0.42.0から0.49.0へアップデート

### DIFF
--- a/argoproj/openhands/deployment.yaml
+++ b/argoproj/openhands/deployment.yaml
@@ -20,12 +20,12 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: openhands
-        image: docker.all-hands.dev/all-hands-ai/openhands:0.42.0
+        image: docker.all-hands.dev/all-hands-ai/openhands:0.49.0
         ports:
         - containerPort: 3000
         env:
         - name: SANDBOX_RUNTIME_CONTAINER_IMAGE
-          value: docker.all-hands.dev/all-hands-ai/runtime:0.42.0-nikolaik
+          value: docker.all-hands.dev/all-hands-ai/runtime:0.49.0-nikolaik
         - name: SANDBOX_LOCAL_RUNTIME_URL
           value: http://127.0.0.1
         # 注意: このIPアドレスは実際のgolyat-1ノードのIPアドレスに置き換えてください


### PR DESCRIPTION
## Summary
- OpenHandsのDockerイメージを最新バージョン(0.49.0)へアップデート
- メインコンテナとランタイムコンテナの両方のイメージタグを更新

## 変更内容
- `openhands:0.42.0` → `openhands:0.49.0`
- `runtime:0.42.0-nikolaik` → `runtime:0.49.0-nikolaik`

## Test plan
- [ ] ArgoCDでの差分確認
- [ ] デプロイ後のアプリケーション動作確認
- [ ] ランタイムコンテナの正常起動確認

🤖 Generated with [Claude Code](https://claude.ai/code)