### PR TITLE
feat: Configure ArgoCD Image Updater for ark-discord-bot

### DIFF
--- a/argoproj/ark-discord-bot/application.yaml
+++ b/argoproj/ark-discord-bot/application.yaml
@@ -5,12 +5,20 @@ metadata:
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: bot=boxp/ark-discord-bot
+    argocd-image-updater.argoproj.io/bot.update-strategy: semver
+    argocd-image-updater.argoproj.io/bot.allow-tags: "re:^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: default
   source:
     repoURL: https://github.com/boxp/lolice.git
     path: argoproj/ark-discord-bot
     targetRevision: HEAD
+    kustomize:
+      images:
+        - bot:v0.0.1_test
   destination:
     server: https://kubernetes.default.svc
     namespace: ark-discord-bot

--- a/argoproj/ark-discord-bot/deployment.yaml
+++ b/argoproj/ark-discord-bot/deployment.yaml
@@ -28,8 +28,8 @@ spec:
         runAsGroup: 10000
         fsGroup: 10000
       containers:
-      - name: ark-discord-bot
-        image: 839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/ark-discord-bot:v20250715-751c1c0
+      - name: ark-discord-bot # an alias
+        image: boxp/ark-discord-bot:v0.0.1_test
         imagePullPolicy: Always
         envFrom:
         - configMapRef:

--- a/argoproj/ark-discord-bot/kustomization.yaml
+++ b/argoproj/ark-discord-bot/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: ark-discord-bot
-
+images:
+  - name: bot
+    newName: boxp/ark-discord-bot
+    newTag: v0.0.1
 resources:
-  - application.yaml
   - namespace.yaml
   - external-secret.yaml
   - configmap.yaml


### PR DESCRIPTION
This PR configures ArgoCD Image Updater for the `ark-discord-bot` project.

### Changes
- Added Image Updater annotations to `application.yaml`.
- Set the `write-back-method` to `argocd`.
- Updated `deployment.yaml` and `kustomization.yaml` to use an image alias.
- Added the initial image version to `application.yaml`.