### PR TITLE
fix(ark-discord-bot): Align Image Updater Config with Palserver

### DIFF
--- a/argoproj/ark-discord-bot/application.yaml
+++ b/argoproj/ark-discord-bot/application.yaml
@@ -6,10 +6,9 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd-image-updater.argoproj.io/image-list: bot=boxp/ark-discord-bot
-    argocd-image-updater.argoproj.io/bot.update-strategy: semver
-    argocd-image-updater.argoproj.io/bot.allow-tags: "re:^v[0-9]+\\.[0-9]+\\.[0-9]+$"
-    argocd-image-updater.argoproj.io/write-back-method: argocd
+    argocd-image-updater.argoproj.io/image-list: bot=839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/ark-discord-bot
+    argocd-image-updater.argoproj.io/bot.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/write-back-method: argocd 
 spec:
   project: default
   source:

--- a/argoproj/ark-discord-bot/deployment.yaml
+++ b/argoproj/ark-discord-bot/deployment.yaml
@@ -28,8 +28,8 @@ spec:
         runAsGroup: 10000
         fsGroup: 10000
       containers:
-      - name: ark-discord-bot # an alias
-        image: boxp/ark-discord-bot:v0.0.1_test
+      - name: bot
+        image: bot:v0.0.1_test
         imagePullPolicy: Always
         envFrom:
         - configMapRef:

--- a/argoproj/ark-discord-bot/kustomization.yaml
+++ b/argoproj/ark-discord-bot/kustomization.yaml
@@ -2,10 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: ark-discord-bot
-images:
-  - name: bot
-    newName: boxp/ark-discord-bot
-    newTag: v0.0.1
 resources:
   - namespace.yaml
   - external-secret.yaml


### PR DESCRIPTION
This PR fixes the ArgoCD Image Updater configuration for the `ark-discord-bot` project by aligning it with the `palserver` implementation.

### Key Changes
- **Corrected ECR Repository Path**: The `image-list` annotation in `application.yaml` now points to the full ECR repository URL, resolving the "repository not found" error.
- **Aligned Update Strategy**: The update strategy has been changed from `semver` to `newest-build` to match `palserver`.
- **Simplified Kustomize Configuration**: Removed the `images` directive from `kustomization.yaml` to prevent conflicts with the `write-back-method: argocd`, which updates the `Application` resource directly.
- **Unified Image Alias**: The container name and image reference in `deployment.yaml` are now consistently set to the alias `bot`, ensuring that updates from the `Application` resource are correctly applied.

These changes ensure that the Image Updater correctly monitors the ECR repository and updates the application as expected.