### PR TITLE
feat(longhorn): ノード障害時の自動フェイルオーバーを改善する設定を追加

### DIFF
--- a/argoproj/longhorn/kustomization.yaml
+++ b/argoproj/longhorn/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: longhorn-system
+
+resources:
+  - external-secret.yaml
+  - cloudflare-deployment.yaml
+  - settings.yaml

--- a/argoproj/longhorn/settings.yaml
+++ b/argoproj/longhorn/settings.yaml
@@ -1,0 +1,36 @@
+# Longhornフェイルオーバー改善設定
+# ノード障害時の自動フェイルオーバーを改善するための設定
+apiVersion: longhorn.io/v1beta1
+kind: Setting
+metadata:
+  name: node-down-pod-deletion-policy
+  namespace: longhorn-system
+value: "delete-both-statefulset-and-deployment-pod"
+---
+apiVersion: longhorn.io/v1beta1
+kind: Setting
+metadata:
+  name: auto-delete-pod-when-volume-detached-unexpectedly
+  namespace: longhorn-system
+value: "true"
+---
+apiVersion: longhorn.io/v1beta1
+kind: Setting
+metadata:
+  name: detach-manually-attached-volumes-when-cordoned
+  namespace: longhorn-system
+value: "true"
+---
+apiVersion: longhorn.io/v1beta1
+kind: Setting
+metadata:
+  name: replica-soft-anti-affinity
+  namespace: longhorn-system
+value: "true"
+---
+apiVersion: longhorn.io/v1beta1
+kind: Setting
+metadata:
+  name: replica-auto-balance
+  namespace: longhorn-system
+value: "least-effort"


### PR DESCRIPTION
## 概要
Longhornストレージシステムのノード障害時の自動フェイルオーバー機能を改善する設定を追加します。

## 背景
golyat-1ノードのメンテナンス時に、ボリュームアタッチメントの競合により多数のPodが正常に稼働できない問題が発生しました。
RWO（ReadWriteOnce）ボリュームが適切にデタッチされず、新しいノードでマウントできない状態となっていました。

## 変更内容
以下のLonghorn設定を追加：

### 1. `node-down-pod-deletion-policy: delete-both-statefulset-and-deployment-pod`
- 現在の`do-nothing`から変更
- ノード障害時にStatefulSetとDeploymentの両方のPodを自動削除

### 2. `auto-delete-pod-when-volume-detached-unexpectedly: true`
- ボリュームが予期せずデタッチされた場合、関連するPodを自動削除

### 3. `detach-manually-attached-volumes-when-cordoned: true`
- ノードがcordonされた時に手動でアタッチされたボリュームを自動デタッチ

### 4. `replica-soft-anti-affinity: true`
- レプリカを異なるノードに分散配置するよう促進

### 5. `replica-auto-balance: least-effort`
- レプリカの自動バランシングを有効化（最小限の移動で最適化）

## 期待される効果
- ノード障害時の自動フェイルオーバーが迅速に実行される
- ボリュームアタッチメントの競合が解消される
- 計画的なノードメンテナンス時の問題が減少する
- ストレージの可用性が向上する

## テスト項目
- [ ] ArgoCDでの同期が正常に完了すること
- [ ] Longhorn UIで設定が反映されていること
- [ ] ノードのcordon/drain時にボリュームが適切に移行すること

🤖 Generated with [Claude Code](https://claude.ai/code)