### PR TITLE
feat: Add Cloudflare tunnel configuration for kubernetes-dashboard

### DIFF
--- a/argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
+++ b/argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: kube-dashboard
+spec:
+  selector:
+    matchLabels:
+      app: cloudflared
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+      - name: cloudflared
+        image: docker.io/cloudflare/cloudflared:2025.7.0
+        ports:
+          - name: metrics
+            containerPort: 2000
+        imagePullPolicy: IfNotPresent
+        args:
+        - tunnel
+        - --metrics
+        - 0.0.0.0:2000
+        - run
+        - --token
+        - $(TUNNEL_TOKEN)
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 2000
+          failureThreshold: 1
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        env:
+          - name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tunnel-credentials
+                key: tunnel-token

--- a/argoproj/kubernetes-dashboard/manifests/external-secret.yaml
+++ b/argoproj/kubernetes-dashboard/manifests/external-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: external-secret
+  namespace: kube-dashboard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: tunnel-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: tunnel-token
+    remoteRef:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: kubernetes-dashboard-tunnel-token
+      metadataPolicy: None

--- a/argoproj/kubernetes-dashboard/manifests/kustomization.yaml
+++ b/argoproj/kubernetes-dashboard/manifests/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - cloudflared-deployment.yaml
+  - external-secret.yaml


### PR DESCRIPTION
## Summary
- Add Cloudflare tunnel configuration for kubernetes-dashboard
- Configure External Secret to fetch tunnel token from AWS SSM
- Expose service at kubernetes-dashboard.b0xp.io

## Changes
- Added cloudflared deployment in `argoproj/kubernetes-dashboard/manifests/`
- Configured External Secret to pull tunnel token from SSM parameter `kubernetes-dashboard-tunnel-token`
- Added kustomization.yaml to manage all manifests

## Related PRs
- arch infrastructure PR: https://github.com/boxp/arch/pull/4321

## Test plan
- [ ] Verify kustomize build runs successfully
- [ ] After arch PR is merged and applied, verify External Secret syncs successfully
- [ ] Verify cloudflared pod starts and connects to Cloudflare
- [ ] Verify kubernetes-dashboard is accessible at https://kubernetes-dashboard.b0xp.io

🤖 Generated with [Claude Code](https://claude.ai/code)