### PR TITLE
fix: ark-discord-botの重複Application問題を修正

### DIFF
--- a/argoproj/ark-discord-bot/kustomization.yaml
+++ b/argoproj/ark-discord-bot/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 namespace: ark-discord-bot
 resources:
-  - application.yaml
   - namespace.yaml
   - external-secret.yaml
   - configmap.yaml


### PR DESCRIPTION
## Summary
- argocd-image-updaterが「multiple applications found」エラーで更新に失敗する問題を修正
- kustomization.yamlからapplication.yamlの参照を削除

## 問題の詳細
argocd-image-updaterがark-discord-botのイメージ更新時に以下のエラーを出していました：
```
could not get application: ark-discord-bot, error: multiple applications found matching ark-discord-bot
```

### 原因
1. argocd-appsが`argoproj/ark-discord-bot/application.yaml`を管理（argocd名前空間）
2. ark-discord-bot自体の`kustomization.yaml`も同じ`application.yaml`を参照
3. 結果として、ark-discord-bot名前空間にも重複したApplicationリソースが作成されていた

### 修正内容
`argoproj/ark-discord-bot/kustomization.yaml`から`application.yaml`の参照を削除しました。
これにより、Applicationリソースはargocd名前空間にのみ存在するようになり、重複が解消されます。

## Test plan
- [ ] PRマージ後、ArgoCDでark-discord-botアプリケーションが正常に同期されることを確認
- [ ] ark-discord-bot名前空間に重複したApplicationリソースが存在しないことを確認
- [ ] argocd-image-updaterが正常にイメージを更新できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)