### PR TITLE
feat: Add kube-vip DaemonSet as ArgoCD application

### DIFF
--- a/argoproj/kube-vip/application.yaml
+++ b/argoproj/kube-vip/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-vip
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boxp/lolice.git
+    path: argoproj/kube-vip
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/argoproj/kube-vip/daemonset.yaml
+++ b/argoproj/kube-vip/daemonset.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-vip-ds
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: kube-vip
+  template:
+    metadata:
+      labels:
+        app: kube-vip
+    spec:
+      serviceAccountName: kube-vip
+      # マスター／コントロールプレーンノードのみに配置
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - operator: Exists        # 全ての taint を許容
+      hostNetwork: true          # VIP をホストネットワークで告知
+      containers:
+      - name: kube-vip
+        image: ghcr.io/kube-vip/kube-vip:v0.8.7
+        imagePullPolicy: Always
+        args: ["manager"]
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW", "SYS_TIME"]
+        env:
+        - name: vip_arp
+          value: "true"
+        - name: port
+          value: "6443"
+        - name: vip_interface
+          value: "eth0"
+        - name: vip_cidr
+          value: "32"
+        - name: dns_mode
+          value: "first"
+        - name: cp_enable
+          value: "true"
+        - name: cp_namespace
+          value: "kube-system"
+        - name: svc_enable
+          value: "true"
+        - name: svc_leasename
+          value: "plndr-svcs-lock"
+        - name: vip_leaderelection
+          value: "true"
+        - name: vip_leasename
+          value: "plndr-cp-lock"
+        - name: vip_leaseduration
+          value: "5"
+        - name: vip_renewdeadline
+          value: "3"
+        - name: vip_retryperiod
+          value: "1"
+        - name: address
+          value: "192.168.10.99"
+        - name: prometheus_server
+          value: ":2112"

--- a/argoproj/kube-vip/kustomization.yaml
+++ b/argoproj/kube-vip/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+resources:
+  - rbac.yaml
+  - daemonset.yaml

--- a/argoproj/kube-vip/rbac.yaml
+++ b/argoproj/kube-vip/rbac.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-vip-role
+rules:
+- apiGroups: [""]
+  resources: ["services", "services/status", "endpoints", "configmaps", "nodes"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-vip-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-vip-role
+subjects:
+- kind: ServiceAccount
+  name: kube-vip
+  namespace: kube-system


### PR DESCRIPTION
kube-vipをDaemonSetとしてデプロイするための新しいArgoCD applicationを追加しました。

## 変更内容
- RBACリソースの作成（ServiceAccount、ClusterRole、ClusterRoleBinding）
- コントロールプレーンノードのみへのDaemonSet設定
- VIP 192.168.10.99での適切なネットワーキング設定
- 環境変数の構文修正

Closes #125

Generated with [Claude Code](https://claude.ai/code)