### PR TITLE
fix: cloudflaredのUDPバッファサイズエラーを修正

### DIFF
--- a/argoproj/argocd/cloudflared-deployment.yaml
+++ b/argoproj/argocd/cloudflared-deployment.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2025.7.0

--- a/argoproj/boxp-home/cloudflared-deployment.yaml
+++ b/argoproj/boxp-home/cloudflared-deployment.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:latest

--- a/argoproj/hitohub/overlays/prod/deployment-cloudflared.yaml
+++ b/argoproj/hitohub/overlays/prod/deployment-cloudflared.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2025.7.0

--- a/argoproj/hitohub/overlays/stage/deployment-cloudflared.yaml
+++ b/argoproj/hitohub/overlays/stage/deployment-cloudflared.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2025.7.0

--- a/argoproj/k8s/cloudflared-deployment.yaml
+++ b/argoproj/k8s/cloudflared-deployment.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2025.7.0

--- a/argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
+++ b/argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2025.7.0

--- a/argoproj/longhorn/cloudflare-deployment.yaml
+++ b/argoproj/longhorn/cloudflare-deployment.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:1517-bb29a0e19437

--- a/argoproj/openhands/cloudflared-deployment.yaml
+++ b/argoproj/openhands/cloudflared-deployment.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:latest

--- a/argoproj/prometheus-operator/cloudflared-deployment.yaml
+++ b/argoproj/prometheus-operator/cloudflared-deployment.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: cloudflared
     spec:
+      securityContext:
+        sysctls:
+        - name: net.core.rmem_max
+          value: "7340032"
+        - name: net.core.wmem_max
+          value: "7340032"
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2025.7.0


### PR DESCRIPTION
## Summary
- cloudflaredでQUICプロトコルのUDPバッファサイズ不足エラーが発生していた問題を修正
- 全cloudflaredデプロイメントにsysctlパラメータを追加してバッファサイズを7MBに増加

## Changes
- `net.core.rmem_max: 7340032` (receive buffer)
- `net.core.wmem_max: 7340032` (write buffer)

## Affected Files
- argoproj/argocd/cloudflared-deployment.yaml
- argoproj/boxp-home/cloudflared-deployment.yaml  
- argoproj/hitohub/overlays/prod/deployment-cloudflared.yaml
- argoproj/hitohub/overlays/stage/deployment-cloudflared.yaml
- argoproj/k8s/cloudflared-deployment.yaml
- argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
- argoproj/longhorn/cloudflare-deployment.yaml
- argoproj/openhands/cloudflared-deployment.yaml
- argoproj/prometheus-operator/cloudflared-deployment.yaml

## Test plan
- [ ] ArgoCDで各アプリケーションの同期状況を確認
- [ ] cloudflaredポッドのログでUDPバッファサイズエラーが解消されているか確認
- [ ] トンネル接続が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)