### PR TITLE
fix: cloudflaredオプションの並び順を修正

### DIFF
--- a/argoproj/argocd/cloudflared-deployment.yaml
+++ b/argoproj/argocd/cloudflared-deployment.yaml
@@ -21,13 +21,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
-        - run
-        - --protocol
-        - http2
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
         # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
+        - run
+        - --protocol
+        - http2
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/boxp-home/cloudflared-deployment.yaml
+++ b/argoproj/boxp-home/cloudflared-deployment.yaml
@@ -22,11 +22,11 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
+        - --metrics
+        - 0.0.0.0:2000
         - run
         - --protocol
         - http2
-        - --metrics
-        - 0.0.0.0:2000
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/hitohub/overlays/prod/deployment-cloudflared.yaml
+++ b/argoproj/hitohub/overlays/prod/deployment-cloudflared.yaml
@@ -21,13 +21,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
-        - run
-        - --protocol
-        - http2
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
         # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
+        - run
+        - --protocol
+        - http2
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/hitohub/overlays/stage/deployment-cloudflared.yaml
+++ b/argoproj/hitohub/overlays/stage/deployment-cloudflared.yaml
@@ -21,13 +21,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
-        - run
-        - --protocol
-        - http2
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
         # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
+        - run
+        - --protocol
+        - http2
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/k8s/cloudflared-deployment.yaml
+++ b/argoproj/k8s/cloudflared-deployment.yaml
@@ -21,13 +21,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
-        - run
-        - --protocol
-        - http2
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
         # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
+        - run
+        - --protocol
+        - http2
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
+++ b/argoproj/kubernetes-dashboard/manifests/cloudflared-deployment.yaml
@@ -22,11 +22,11 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
+        - --metrics
+        - 0.0.0.0:2000
         - run
         - --protocol
         - http2
-        - --metrics
-        - 0.0.0.0:2000
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/longhorn/cloudflare-deployment.yaml
+++ b/argoproj/longhorn/cloudflare-deployment.yaml
@@ -21,13 +21,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
-        - run
-        - --protocol
-        - http2
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on. 
         # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
+        - run
+        - --protocol
+        - http2
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/openhands/cloudflared-deployment.yaml
+++ b/argoproj/openhands/cloudflared-deployment.yaml
@@ -21,11 +21,11 @@ spec:
             containerPort: 2000
         args:
         - tunnel
+        - --metrics
+        - 0.0.0.0:2000
         - run
         - --protocol
         - http2
-        - --metrics
-        - 0.0.0.0:2000
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:

--- a/argoproj/prometheus-operator/cloudflared-deployment.yaml
+++ b/argoproj/prometheus-operator/cloudflared-deployment.yaml
@@ -21,13 +21,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - tunnel
-        - run
-        - --protocol
-        - http2
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
         # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
+        - run
+        - --protocol
+        - http2
         - --token
         - $(TUNNEL_TOKEN)
         livenessProbe:


### PR DESCRIPTION
--metricsオプションをrunサブコマンドの前に移動して
正しいCLI構文に修正:
tunnel --metrics 0.0.0.0:2000 run --protocol http2 --token TOKEN

🤖 Generated with [Claude Code](https://claude.ai/code)