### PR TITLE
fix: LonghornバックアップターゲットのS3バケット名を正しい名前に修正

### DIFF
--- a/argoproj/longhorn/settings.yaml
+++ b/argoproj/longhorn/settings.yaml
@@ -48,7 +48,7 @@ kind: Setting
 metadata:
   name: backup-target
   namespace: longhorn-system
-value: "s3://longhorn-backup@ap-northeast-1/"
+value: "s3://boxp-longhorn-backup@ap-northeast-1/"
 ---
 apiVersion: longhorn.io/v1beta1
 kind: Setting


### PR DESCRIPTION
- backup-target設定を s3://longhorn-backup から s3://boxp-longhorn-backup に変更
- arch側で作成された実際のS3バケット名と一致させる
- これによりlonghorn-backup-secretエラーが解決される

🤖 Generated with [Claude Code](https://claude.ai/code)