### PR TITLE
fix: Longhorn v1.9.1設定をHelmチャート値に移行

### DIFF
--- a/argoproj/longhorn/application.yaml
+++ b/argoproj/longhorn/application.yaml
@@ -13,7 +13,13 @@ spec:
         values: |
           preUpgradeChecker:
             jobEnabled: false
-          defaultSettings.defaultReplicaCount: 2
+          defaultSettings:
+            defaultReplicaCount: 2
+            backupTarget: "s3://boxp-longhorn-backup@ap-northeast-1/"
+            backupTargetCredentialSecret: "longhorn-backup-secret"
+          global:
+            storageClass:
+              reclaimPolicy: "Retain"
           metrics:
             serviceMonitor:
               enabled: true

--- a/argoproj/longhorn/settings.yaml
+++ b/argoproj/longhorn/settings.yaml
@@ -34,25 +34,3 @@ metadata:
   name: replica-auto-balance
   namespace: longhorn-system
 value: "least-effort"
----
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: storage-class-reclaim-policy
-  namespace: longhorn-system
-value: "Retain"
----
-# S3バックアップ設定
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: backup-target
-  namespace: longhorn-system
-value: "s3://boxp-longhorn-backup@ap-northeast-1/"
----
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: backup-target-credential-secret
-  namespace: longhorn-system
-value: "longhorn-backup-secret"


### PR DESCRIPTION
Longhorn v1.9.1で非対応になったSetting APIからHelmチャート値への移行を実施。

Closes #240

Generated with [Claude Code](https://claude.ai/code)