### PR TITLE
BOXP-7: Add Codex workspace manifests

### DIFF
--- a/argoproj/codex-workspace/application.yaml
+++ b/argoproj/codex-workspace/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: codex-workspace
+  namespace: argocd
+spec:
+  destination:
+    namespace: codex-workspace
+    server: https://kubernetes.default.svc
+  project: default
+  sources:
+    - path: argoproj/codex-workspace
+      repoURL: https://github.com/boxp/lolice
+      targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argoproj/codex-workspace/configmap.yaml
+++ b/argoproj/codex-workspace/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: codex-workspace-sshd-config
+  namespace: codex-workspace
+data:
+  sshd_config: |
+    Port 2222
+    PermitRootLogin no
+    PasswordAuthentication no
+    PubkeyAuthentication yes
+    AuthorizedKeysFile /home/%u/.ssh/authorized_keys
+    AllowTcpForwarding yes
+    GatewayPorts no
+    X11Forwarding no
+    ClientAliveInterval 60
+    ClientAliveCountMax 3
+    Subsystem sftp /usr/lib/openssh/sftp-server

--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-workspace
+  namespace: codex-workspace
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: codex-workspace
+  template:
+    metadata:
+      labels:
+        app: codex-workspace
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      initContainers:
+        - name: fetch-ssh-keys
+          image: docker.io/curlimages/curl:8.20.0
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              curl -fsSL https://github.com/boxp.keys -o /authorized-keys/authorized_keys
+              test -s /authorized-keys/authorized_keys
+              chmod 644 /authorized-keys/authorized_keys
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: authorized-keys
+              mountPath: /authorized-keys
+      containers:
+        - name: workspace
+          image: ghcr.io/boxp/arch/codex-workspace:latest
+          imagePullPolicy: Always
+          ports:
+            - name: ssh
+              containerPort: 2222
+            - name: even-terminal
+              containerPort: 3456
+          env:
+            - name: EVEN_TERMINAL_PORT
+              value: "3456"
+            - name: EVEN_TERMINAL_CWD
+              value: /home/boxp
+            - name: EVEN_TERMINAL_PROVIDER
+              value: codex
+            - name: EVEN_TERMINAL_NAME
+              value: lolice-codex-workspace
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+          readinessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          volumeMounts:
+            - name: home
+              mountPath: /home/boxp
+            - name: authorized-keys
+              mountPath: /tmp/authorized_keys
+              readOnly: true
+            - name: sshd-config
+              mountPath: /etc/ssh/sshd_config
+              subPath: sshd_config
+              readOnly: true
+      volumes:
+        - name: home
+          persistentVolumeClaim:
+            claimName: codex-workspace-home
+        - name: authorized-keys
+          emptyDir: {}
+        - name: sshd-config
+          configMap:
+            name: codex-workspace-sshd-config

--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -25,20 +25,22 @@ spec:
             - /bin/sh
             - -ec
             - |
-              curl -fsSL https://github.com/boxp.keys -o /authorized-keys/authorized_keys
-              test -s /authorized-keys/authorized_keys
-              chmod 644 /authorized-keys/authorized_keys
+              mkdir -p /home/boxp/.ssh
+              curl -fsSL https://github.com/boxp.keys -o /home/boxp/.ssh/authorized_keys
+              test -s /home/boxp/.ssh/authorized_keys
+              chown -R 1000:1000 /home/boxp/.ssh
+              chmod 700 /home/boxp/.ssh
+              chmod 600 /home/boxp/.ssh/authorized_keys
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsNonRoot: false
+            runAsUser: 0
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: authorized-keys
-              mountPath: /authorized-keys
+            - name: home
+              mountPath: /home/boxp
         - name: install-docker-cli
           image: docker.io/docker:29.1.2-cli
           command:
@@ -104,9 +106,6 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
-            - name: authorized-keys
-              mountPath: /tmp/authorized_keys
-              readOnly: true
             - name: sshd-config
               mountPath: /etc/ssh/sshd_config
               subPath: sshd_config
@@ -145,8 +144,6 @@ spec:
         - name: home
           persistentVolumeClaim:
             claimName: codex-workspace-home
-        - name: authorized-keys
-          emptyDir: {}
         - name: sshd-config
           configMap:
             name: codex-workspace-sshd-config

--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -39,6 +39,24 @@ spec:
           volumeMounts:
             - name: authorized-keys
               mountPath: /authorized-keys
+        - name: install-docker-cli
+          image: docker.io/docker:29.1.2-cli
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp /usr/local/bin/docker /docker-cli/docker
+              chmod 755 /docker-cli/docker
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: docker-cli
+              mountPath: /docker-cli
       containers:
         - name: workspace
           image: ghcr.io/boxp/arch/codex-workspace:latest
@@ -57,6 +75,10 @@ spec:
               value: codex
             - name: EVEN_TERMINAL_NAME
               value: lolice-codex-workspace
+            - name: DOCKER_HOST
+              value: tcp://127.0.0.1:2375
+            - name: DOCKER_BUILDKIT
+              value: "1"
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
@@ -89,6 +111,36 @@ spec:
               mountPath: /etc/ssh/sshd_config
               subPath: sshd_config
               readOnly: true
+            - name: docker-cli
+              mountPath: /usr/local/bin/docker
+              subPath: docker
+              readOnly: true
+        - name: docker
+          image: docker.io/docker:29.1.2-dind
+          imagePullPolicy: IfNotPresent
+          args:
+            - --host=tcp://127.0.0.1:2375
+            - --host=unix:///var/run/docker.sock
+            - --storage-driver=overlay2
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          securityContext:
+            privileged: true
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: docker-graph-storage
+              mountPath: /var/lib/docker
       volumes:
         - name: home
           persistentVolumeClaim:
@@ -98,3 +150,7 @@ spec:
         - name: sshd-config
           configMap:
             name: codex-workspace-sshd-config
+        - name: docker-cli
+          emptyDir: {}
+        - name: docker-graph-storage
+          emptyDir: {}

--- a/argoproj/codex-workspace/kustomization.yaml
+++ b/argoproj/codex-workspace/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml

--- a/argoproj/codex-workspace/namespace.yaml
+++ b/argoproj/codex-workspace/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: codex-workspace
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/argoproj/codex-workspace/networkpolicy.yaml
+++ b/argoproj/codex-workspace/networkpolicy.yaml
@@ -1,0 +1,51 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: codex-workspace-network-policy
+  namespace: codex-workspace
+spec:
+  selector: app == 'codex-workspace'
+  types:
+    - Ingress
+    - Egress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      source:
+        namespaceSelector: kubernetes.io/metadata.name == 'k8s'
+        selector: app == 'cloudflared'
+      destination:
+        ports:
+          - 2222
+          - 3456
+    - action: Allow
+      protocol: TCP
+      source:
+        nets:
+          - 192.168.10.0/24
+      destination:
+        ports:
+          - 2222
+          - 3456
+  egress:
+    - action: Allow
+      protocol: UDP
+      destination:
+        selector: k8s-app == 'kube-dns'
+        namespaceSelector: kubernetes.io/metadata.name == 'kube-system'
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: k8s-app == 'kube-dns'
+        namespaceSelector: kubernetes.io/metadata.name == 'kube-system'
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - 22
+          - 80
+          - 443

--- a/argoproj/codex-workspace/pvc.yaml
+++ b/argoproj/codex-workspace/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: codex-workspace-home
+  namespace: codex-workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 50Gi

--- a/argoproj/codex-workspace/service.yaml
+++ b/argoproj/codex-workspace/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-workspace
+  namespace: codex-workspace
+spec:
+  type: ClusterIP
+  clusterIP: 10.111.250.7
+  selector:
+    app: codex-workspace
+  ports:
+    - name: ssh
+      port: 2222
+      targetPort: ssh
+    - name: even-terminal
+      port: 3456
+      targetPort: even-terminal

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ark-survival-ascended/application.yaml
 - boxp-home/application.yaml
 - calico/application.yaml
+- codex-workspace/application.yaml
 - descheduler/application.yaml
 - external-secrets-operator/application.yaml
 - hitohub/overlays/prod/application.yaml

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -12,6 +12,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - GitHub の `boxp` user に登録されている public key で SSH login できる。
 - Cloudflare WARP 経由で Even Realities App から `@evenrealities/even-terminal` に接続できる。
 - `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` が使える。
+- Docker CLI と dind sidecar で Docker build/run が使える。
 - `/home/boxp` は Longhorn PVC で永続化する。
 - Secret/token は Git に直接置かない。
 
@@ -24,6 +25,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - `boxp/lolice` に `argoproj/codex-workspace` Application を追加する。
   - PVC: Longhorn, mounted at `/home/boxp`
   - SSH authorized keys: initContainer で `https://github.com/boxp.keys` から取得
+  - Docker: `docker:29.1.2-cli` initContainer で CLI を配置し、`docker:29.1.2-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - Service: fixed ClusterIP `10.111.250.7`
   - Ports: SSH `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `10.111.250.7/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -1,0 +1,45 @@
+# BOXP-7: lolice cluster 上に Codex workspace を作成する
+
+## Goal
+
+OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal Mode で作業できる常設 workspace を作成する。
+
+## Requirements
+
+- 最新 Ubuntu LTS ベース。
+- Cloudflare WARP 経由で SSH 接続できる。
+- GitHub の `boxp` user に登録されている public key で SSH login できる。
+- Cloudflare WARP 経由で Even Realities App から `@evenrealities/even-terminal` に接続できる。
+- `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` が使える。
+- `/home/boxp` は Longhorn PVC で永続化する。
+- Secret/token は Git に直接置かない。
+
+## Design
+
+- `boxp/arch` で `ghcr.io/boxp/arch/codex-workspace` image を build する。
+  - base: `ubuntu:26.04`
+  - platform: `linux/amd64`
+  - scheduler: amd64 worker へ固定
+- `boxp/lolice` に `argoproj/codex-workspace` Application を追加する。
+  - PVC: Longhorn, mounted at `/home/boxp`
+  - SSH authorized keys: initContainer で `https://github.com/boxp.keys` から取得
+  - Service: fixed ClusterIP `10.111.250.7`
+  - Ports: SSH `2222`, Even Terminal `3456`
+- `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `10.111.250.7/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
+
+## Tasks
+
+- [x] チケットを起票する。
+- [x] Even G2 Terminal Mode と `@evenrealities/even-terminal` の接続モデルを確認する。
+- [x] 既存の bastion/Cloudflare/Longhorn PVC パターンを確認する。
+- [x] `boxp/arch` に workspace image build と Cloudflare WARP private route を追加する。
+- [x] `boxp/lolice` に codex workspace Application を追加する。
+- [x] kustomize と Terraform validate を通す。
+- [ ] PR を作成する。
+
+## Verification
+
+- `kubectl kustomize argoproj/codex-workspace`
+- `kubectl kustomize argoproj`
+- `kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -`
+- `kubectl get svc -A` で ClusterIP `10.111.250.7` が未使用であることを確認。

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -8,6 +8,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 
 - 最新 Ubuntu LTS ベース。
 - Cloudflare WARP 経由で SSH 接続できる。
+- Cloudflare WARP 経由で `codex-workspace.b0xp.io` hostname でも接続できる。
 - GitHub の `boxp` user に登録されている public key で SSH login できる。
 - Cloudflare WARP 経由で Even Realities App から `@evenrealities/even-terminal` に接続できる。
 - `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` が使える。
@@ -26,6 +27,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - Service: fixed ClusterIP `10.111.250.7`
   - Ports: SSH `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `10.111.250.7/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
+- `boxp/arch` の Cloudflare DNS に `codex-workspace.b0xp.io` DNS-only A record を追加し、`10.111.250.7` に解決させる。
 
 ## Tasks
 


### PR DESCRIPTION
## Summary

- Add a codex-workspace ArgoCD Application for the lolice cluster.
- Persist /home/boxp on a Longhorn PVC and expose SSH 2222 plus even-terminal 3456 on fixed ClusterIP 10.111.250.7.
- Use codex-workspace.b0xp.io as the WARP hostname for SSH and even-terminal access.
- Fetch GitHub user boxp public keys from https://github.com/boxp.keys and write them to /home/boxp/.ssh/authorized_keys for SSH login.
- Schedule the workspace on amd64 workers only.
- Add dind support with docker:29.1.2-dind sidecar and docker:29.1.2-cli injected into the workspace container.

## Validation

- kubectl kustomize argoproj/codex-workspace
- kubectl kustomize argoproj
- kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -
- kubectl get svc -A confirmed 10.111.250.7 was unused before assigning it
- docker manifest inspect ghcr.io/boxp/arch/codex-workspace:latest confirmed linux/amd64 image is published
- docker manifest inspect docker.io/docker:29.1.2-cli and docker.io/docker:29.1.2-dind confirmed amd64 images exist