### PR TITLE
BOXP-7: Use replica-2 Longhorn storage for Codex workspace

### DIFF
--- a/argoproj/codex-workspace/kustomization.yaml
+++ b/argoproj/codex-workspace/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - storageclass.yaml
   - pvc.yaml
   - configmap.yaml
   - deployment.yaml

--- a/argoproj/codex-workspace/pvc.yaml
+++ b/argoproj/codex-workspace/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn
+  storageClassName: codex-workspace-longhorn
   resources:
     requests:
       storage: 50Gi

--- a/argoproj/codex-workspace/storageclass.yaml
+++ b/argoproj/codex-workspace/storageclass.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: codex-workspace-longhorn
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "2"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: ext4
+  dataLocality: disabled
+  unmapMarkSnapChainRemoved: ignored
+  disableRevisionCounter: "true"
+  dataEngine: v1
+  backupTargetName: default

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -24,6 +24,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - scheduler: amd64 worker へ固定
 - `boxp/lolice` に `argoproj/codex-workspace` Application を追加する。
   - PVC: Longhorn, mounted at `/home/boxp`
+  - StorageClass: `codex-workspace-longhorn`, replica 2. `golyat-3` の Longhorn disk が schedulable=false のため default replica 3 では新規 volume が scheduling できない。
   - SSH authorized keys: initContainer で `https://github.com/boxp.keys` から取得
   - Docker: `docker:29.1.2-cli` initContainer で CLI を配置し、`docker:29.1.2-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - Service: fixed ClusterIP `10.111.250.7`


### PR DESCRIPTION
## Summary

- Add a codex-workspace-specific Longhorn StorageClass with numberOfReplicas=2.
- Point the codex-workspace home PVC at that StorageClass.
- Document why replica 2 is required: the current default replica 3 cannot schedule because only two Longhorn disks are schedulable.

## Validation

- kubectl kustomize argoproj/codex-workspace
- kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -
- kubectl describe volumes.longhorn.io showed the first default replica-3 volume faulted with ReplicaSchedulingFailure: disks are unavailable; insufficient storage; precheck new replica failed
- kubectl get nodes.longhorn.io showed golyat-3 disk schedulable=false