### PR TITLE
BOXP-7: Reduce Codex workspace PVC to 10Gi

### DIFF
--- a/argoproj/codex-workspace/pvc.yaml
+++ b/argoproj/codex-workspace/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: codex-workspace-longhorn
   resources:
     requests:
-      storage: 50Gi
+      storage: 10Gi

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -24,7 +24,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - scheduler: amd64 worker へ固定
 - `boxp/lolice` に `argoproj/codex-workspace` Application を追加する。
   - PVC: Longhorn, mounted at `/home/boxp`
-  - StorageClass: `codex-workspace-longhorn`, replica 2. `golyat-3` の Longhorn disk が schedulable=false のため default replica 3 では新規 volume が scheduling できない。
+  - StorageClass: `codex-workspace-longhorn`, replica 2. `golyat-3` の Longhorn disk が schedulable=false のため default replica 3 では新規 volume が scheduling できない。Longhorn の最小空き率制約に合わせて初期容量は 10Gi にし、空きを作ってから拡張する。
   - SSH authorized keys: initContainer で `https://github.com/boxp.keys` から取得
   - Docker: `docker:29.1.2-cli` initContainer で CLI を配置し、`docker:29.1.2-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - Service: fixed ClusterIP `10.111.250.7`


### PR DESCRIPTION
## Summary

- Reduce the codex-workspace home PVC from 50Gi to 10Gi.
- Keep the replica-2 Longhorn StorageClass from the previous follow-up.
- Document that the current Longhorn minimal available percentage prevents scheduling a 50Gi volume even with two replicas.

## Validation

- kubectl kustomize argoproj/codex-workspace
- kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -
- kubectl describe volumes.longhorn.io for the 50Gi replica-2 volume still showed ReplicaSchedulingFailure
- Longhorn settings: storage-minimal-available-percentage=25, storage-over-provisioning-percentage=100