### PR TITLE
BOXP-7: Avoid duplicate dind TCP listener

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -119,6 +119,7 @@ spec:
           image: docker.io/docker:29.5.1-dind
           imagePullPolicy: IfNotPresent
           args:
+            - dockerd
             - --host=tcp://127.0.0.1:2375
             - --host=unix:///var/run/docker.sock
             - --storage-driver=overlay2

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -28,6 +28,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - SSH authorized keys: initContainer で `https://github.com/boxp.keys` から取得
   - `fetch-ssh-keys` initContainer は Longhorn PVC 上の `/home/boxp/.ssh` を更新し、`boxp` user 所有にするため、`CHOWN`/`DAC_OVERRIDE`/`FOWNER` capability だけを追加する。
   - Docker: `docker:29.5.1-cli` initContainer で CLI を配置し、`docker:29.5.1-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
+  - dind sidecar は args 先頭に `dockerd` を明示し、`docker:dind` entrypoint が既定の `0.0.0.0:2375` listener を追加して `127.0.0.1:2375` と重複 bind しないようにする。
   - Service: fixed ClusterIP `10.111.250.7`
   - Ports: SSH `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `10.111.250.7/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
@@ -42,6 +43,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] `boxp/lolice` に codex workspace Application を追加する。
 - [x] Longhorn の replica/scheduling 制約に合わせて Codex workspace PVC を replica 2 / 10Gi に調整する。
 - [x] `fetch-ssh-keys` initContainer が Longhorn PVC 上で authorized_keys を更新し、owner/mode 設定できるように capability を追加する。
+- [x] dind sidecar の args を明示的な `dockerd` 起動にして TCP listener の重複 bind を避ける。
 - [x] kustomize と Terraform validate を通す。
 - [x] PR を作成する。
 


### PR DESCRIPTION
## Summary

- add explicit `dockerd` command to the Codex workspace dind sidecar args
- avoid docker:dind entrypoint adding the default `0.0.0.0:2375` listener on top of the configured `127.0.0.1:2375` listener
- update the BOXP-7 plan with the dind listener note

## Verification

- `kubectl kustomize argoproj/codex-workspace`
- `kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -`
- `git diff --check origin/main...HEAD`