### PR TITLE
BOXP-7: Expose Codex workspace with LoadBalancer IP

### DIFF
--- a/argoproj/codex-workspace/service.yaml
+++ b/argoproj/codex-workspace/service.yaml
@@ -4,8 +4,8 @@ metadata:
   name: codex-workspace
   namespace: codex-workspace
 spec:
-  type: ClusterIP
-  clusterIP: 10.111.250.7
+  type: LoadBalancer
+  loadBalancerIP: 192.168.10.98
   selector:
     app: codex-workspace
   ports:

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -29,10 +29,10 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - `fetch-ssh-keys` initContainer は Longhorn PVC 上の `/home/boxp/.ssh` を更新し、`boxp` user 所有にするため、`CHOWN`/`DAC_OVERRIDE`/`FOWNER` capability だけを追加する。
   - Docker: `docker:29.5.1-cli` initContainer で CLI を配置し、`docker:29.5.1-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - dind sidecar は args 先頭に `dockerd` を明示し、`docker:dind` entrypoint が既定の `0.0.0.0:2375` listener を追加して `127.0.0.1:2375` と重複 bind しないようにする。
-  - Service: fixed ClusterIP `10.111.250.7`
+  - Service: fixed LoadBalancer IP `192.168.10.98`
   - Ports: SSH `2222`, Even Terminal `3456`
-- `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `10.111.250.7/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
-- `boxp/arch` の Cloudflare DNS に `codex-workspace.b0xp.io` DNS-only A record を追加し、`10.111.250.7` に解決させる。
+- `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `192.168.10.98/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
+- `boxp/arch` の Cloudflare DNS に `codex-workspace.b0xp.io` DNS-only A record を追加し、`192.168.10.98` に解決させる。
 
 ## Tasks
 
@@ -44,6 +44,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] Longhorn の replica/scheduling 制約に合わせて Codex workspace PVC を replica 2 / 10Gi に調整する。
 - [x] `fetch-ssh-keys` initContainer が Longhorn PVC 上で authorized_keys を更新し、owner/mode 設定できるように capability を追加する。
 - [x] dind sidecar の args を明示的な `dockerd` 起動にして TCP listener の重複 bind を避ける。
+- [x] WARP経由のL4到達性を優先し、ServiceをClusterIPからARK serverと同じLoadBalancer IP固定構成へ切り替える。
 - [x] kustomize と Terraform validate を通す。
 - [x] PR を作成する。
 
@@ -52,4 +53,4 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - `kubectl kustomize argoproj/codex-workspace`
 - `kubectl kustomize argoproj`
 - `kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -`
-- `kubectl get svc -A` で ClusterIP `10.111.250.7` が未使用であることを確認。
+- `kubectl get svc -A` で LoadBalancer IP `192.168.10.98` が未使用であることを確認。


### PR DESCRIPTION
## Summary
- change codex-workspace Service from fixed ClusterIP to fixed LoadBalancer IP 192.168.10.98
- keep SSH 2222 and even-terminal 3456 exposed through the same Service
- update the BOXP-7 plan for the ARK-style LoadBalancer route

## Verification
- kubectl kustomize argoproj/codex-workspace
- kubectl kustomize argoproj
- kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -
- kubectl get svc -A confirmed 192.168.10.98 is not assigned to another Service