### PR TITLE
BOXP-7: Allow Codex workspace sshd chroot

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             runAsUser: 0
             allowPrivilegeEscalation: true
             capabilities:
-              add: ["SYS_CHROOT"]
+              add: ["SETGID", "SETUID", "SYS_CHROOT"]
               drop: ["ALL"]
             readOnlyRootFilesystem: false
           resources:

--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -86,6 +86,9 @@ spec:
             runAsNonRoot: false
             runAsUser: 0
             allowPrivilegeEscalation: true
+            capabilities:
+              add: ["SYS_CHROOT"]
+              drop: ["ALL"]
             readOnlyRootFilesystem: false
           resources:
             requests:

--- a/argoproj/codex-workspace/service.yaml
+++ b/argoproj/codex-workspace/service.yaml
@@ -10,7 +10,7 @@ spec:
     app: codex-workspace
   ports:
     - name: ssh
-      port: 2222
+      port: 22
       targetPort: ssh
     - name: even-terminal
       port: 3456

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -29,7 +29,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - `fetch-ssh-keys` initContainer は Longhorn PVC 上の `/home/boxp/.ssh` を更新し、`boxp` user 所有にするため、`CHOWN`/`DAC_OVERRIDE`/`FOWNER` capability だけを追加する。
   - Docker: `docker:29.5.1-cli` initContainer で CLI を配置し、`docker:29.5.1-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - dind sidecar は args 先頭に `dockerd` を明示し、`docker:dind` entrypoint が既定の `0.0.0.0:2375` listener を追加して `127.0.0.1:2375` と重複 bind しないようにする。
-  - Workspace container は OpenSSH privilege separation のため `SYS_CHROOT` capability を持つ。
+  - Workspace container は OpenSSH privilege separation と login user への権限移行のため `SYS_CHROOT`/`SETUID`/`SETGID` capability を持つ。
   - Service: fixed LoadBalancer IP `192.168.10.98`
   - Ports: SSH `22` -> container `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `192.168.10.98/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
@@ -46,7 +46,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] `fetch-ssh-keys` initContainer が Longhorn PVC 上で authorized_keys を更新し、owner/mode 設定できるように capability を追加する。
 - [x] dind sidecar の args を明示的な `dockerd` 起動にして TCP listener の重複 bind を避ける。
 - [x] WARP経由のL4到達性を優先し、ServiceをClusterIPからARK serverと同じLoadBalancer IP固定構成へ切り替える。
-- [x] `sshd` の preauth `chroot("/run/sshd"): Operation not permitted` を避けるため workspace container に `SYS_CHROOT` capability を追加する。
+- [x] `sshd` の preauth `chroot("/run/sshd"): Operation not permitted` と認証後の user/group 権限移行失敗を避けるため workspace container に `SYS_CHROOT`/`SETUID`/`SETGID` capability を追加する。
 - [x] VIP の port 22 が kube-vip holder node の sshd に届かないよう、Service port `22` を workspace ssh へ割り当てる。
 - [x] kustomize と Terraform validate を通す。
 - [x] PR を作成する。

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -29,6 +29,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - `fetch-ssh-keys` initContainer は Longhorn PVC 上の `/home/boxp/.ssh` を更新し、`boxp` user 所有にするため、`CHOWN`/`DAC_OVERRIDE`/`FOWNER` capability だけを追加する。
   - Docker: `docker:29.5.1-cli` initContainer で CLI を配置し、`docker:29.5.1-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - dind sidecar は args 先頭に `dockerd` を明示し、`docker:dind` entrypoint が既定の `0.0.0.0:2375` listener を追加して `127.0.0.1:2375` と重複 bind しないようにする。
+  - Workspace container は OpenSSH privilege separation のため `SYS_CHROOT` capability を持つ。
   - Service: fixed LoadBalancer IP `192.168.10.98`
   - Ports: SSH `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `192.168.10.98/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
@@ -45,6 +46,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] `fetch-ssh-keys` initContainer が Longhorn PVC 上で authorized_keys を更新し、owner/mode 設定できるように capability を追加する。
 - [x] dind sidecar の args を明示的な `dockerd` 起動にして TCP listener の重複 bind を避ける。
 - [x] WARP経由のL4到達性を優先し、ServiceをClusterIPからARK serverと同じLoadBalancer IP固定構成へ切り替える。
+- [x] `sshd` の preauth `chroot("/run/sshd"): Operation not permitted` を避けるため workspace container に `SYS_CHROOT` capability を追加する。
 - [x] kustomize と Terraform validate を通す。
 - [x] PR を作成する。
 

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -31,7 +31,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - dind sidecar は args 先頭に `dockerd` を明示し、`docker:dind` entrypoint が既定の `0.0.0.0:2375` listener を追加して `127.0.0.1:2375` と重複 bind しないようにする。
   - Workspace container は OpenSSH privilege separation のため `SYS_CHROOT` capability を持つ。
   - Service: fixed LoadBalancer IP `192.168.10.98`
-  - Ports: SSH `2222`, Even Terminal `3456`
+  - Ports: SSH `22` -> container `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `192.168.10.98/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
 - `boxp/arch` の Cloudflare DNS に `codex-workspace.b0xp.io` DNS-only A record を追加し、`192.168.10.98` に解決させる。
 
@@ -47,6 +47,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] dind sidecar の args を明示的な `dockerd` 起動にして TCP listener の重複 bind を避ける。
 - [x] WARP経由のL4到達性を優先し、ServiceをClusterIPからARK serverと同じLoadBalancer IP固定構成へ切り替える。
 - [x] `sshd` の preauth `chroot("/run/sshd"): Operation not permitted` を避けるため workspace container に `SYS_CHROOT` capability を追加する。
+- [x] VIP の port 22 が kube-vip holder node の sshd に届かないよう、Service port `22` を workspace ssh へ割り当てる。
 - [x] kustomize と Terraform validate を通す。
 - [x] PR を作成する。
 


### PR DESCRIPTION
## Summary
- add SYS_CHROOT to the codex-workspace container so OpenSSH privilege separation can chroot during preauth
- document the capability requirement in the BOXP-7 plan

## Verification
- kubectl kustomize argoproj/codex-workspace
- kubectl kustomize argoproj
- kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -