### PR TITLE
BOXP-7: Allow Codex workspace home chown

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             runAsUser: 0
             allowPrivilegeEscalation: true
             capabilities:
-              add: ["FOWNER", "SETGID", "SETUID", "SYS_CHROOT"]
+              add: ["CHOWN", "FOWNER", "SETGID", "SETUID", "SYS_CHROOT"]
               drop: ["ALL"]
             readOnlyRootFilesystem: false
           resources:

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -29,7 +29,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
   - `fetch-ssh-keys` initContainer は Longhorn PVC 上の `/home/boxp/.ssh` を更新し、`boxp` user 所有にするため、`CHOWN`/`DAC_OVERRIDE`/`FOWNER` capability だけを追加する。
   - Docker: `docker:29.5.1-cli` initContainer で CLI を配置し、`docker:29.5.1-dind` sidecar を `DOCKER_HOST=tcp://127.0.0.1:2375` で利用する
   - dind sidecar は args 先頭に `dockerd` を明示し、`docker:dind` entrypoint が既定の `0.0.0.0:2375` listener を追加して `127.0.0.1:2375` と重複 bind しないようにする。
-  - Workspace container は `/home/boxp` 初期化、OpenSSH privilege separation、login user への権限移行のため `FOWNER`/`SYS_CHROOT`/`SETUID`/`SETGID` capability を持つ。
+  - Workspace container は `/home/boxp` 初期化、OpenSSH privilege separation、login user への権限移行のため `CHOWN`/`FOWNER`/`SYS_CHROOT`/`SETUID`/`SETGID` capability を持つ。
   - Service: fixed LoadBalancer IP `192.168.10.98`
   - Ports: SSH `22` -> container `2222`, Even Terminal `3456`
 - `boxp/arch` の `terraform/cloudflare/b0xp.io/k8s` で WARP private route `192.168.10.98/32` を追加し、既存 k8s tunnel の `warp_routing` を有効化する。
@@ -48,6 +48,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] WARP経由のL4到達性を優先し、ServiceをClusterIPからARK serverと同じLoadBalancer IP固定構成へ切り替える。
 - [x] `sshd` の preauth `chroot("/run/sshd"): Operation not permitted` と認証後の user/group 権限移行失敗を避けるため workspace container に `SYS_CHROOT`/`SETUID`/`SETGID` capability を追加する。
 - [x] workspace entrypoint が Longhorn PVC 上の `/home/boxp` を chmod できるように `FOWNER` capability を追加する。
+- [x] workspace entrypoint が Longhorn PVC 上の `/home/boxp` を chown できるように `CHOWN` capability を追加する。
 - [x] VIP の port 22 が kube-vip holder node の sshd に届かないよう、Service port `22` を workspace ssh へ割り当てる。
 - [x] kustomize と Terraform validate を通す。
 - [x] PR を作成する。


### PR DESCRIPTION
## Summary
- add CHOWN to workspace container capabilities so the entrypoint can chown the Longhorn-backed /home/boxp
- retain the minimal capabilities needed for sshd and home initialization

## Verification
- kubectl kustomize argoproj/codex-workspace
- kubectl kustomize argoproj
- kubectl kustomize argoproj/codex-workspace | kubectl --dry-run=client apply -f -