### PR TITLE
[codex] Add Grafana MCP access for Codex workspace

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -83,6 +83,13 @@ spec:
                 secretKeyRef:
                   name: codex-workspace-even-terminal
                   key: token
+            - name: GRAFANA_URL
+              value: http://grafana.monitoring.svc.cluster.local:3000
+            - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-grafana
+                  key: service-account-token
             - name: DOCKER_HOST
               value: tcp://127.0.0.1:2375
             - name: DOCKER_BUILDKIT

--- a/argoproj/codex-workspace/external-secret.yaml
+++ b/argoproj/codex-workspace/external-secret.yaml
@@ -15,3 +15,21 @@ spec:
     - secretKey: token
       remoteRef:
         key: /lolice/codex-workspace/even-terminal-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: codex-workspace-grafana
+  namespace: codex-workspace
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: codex-workspace-grafana
+    creationPolicy: Owner
+  data:
+    - secretKey: service-account-token
+      remoteRef:
+        key: /lolice/codex-workspace/grafana-service-account-token

--- a/argoproj/codex-workspace/networkpolicy.yaml
+++ b/argoproj/codex-workspace/networkpolicy.yaml
@@ -45,6 +45,13 @@ spec:
     - action: Allow
       protocol: TCP
       destination:
+        selector: app.kubernetes.io/component == 'grafana' && app.kubernetes.io/name == 'grafana' && app.kubernetes.io/part-of == 'kube-prometheus'
+        namespaceSelector: kubernetes.io/metadata.name == 'monitoring'
+        ports:
+          - 3000
+    - action: Allow
+      protocol: TCP
+      destination:
         ports:
           - 22
           - 80

--- a/argoproj/prometheus-operator/overlays/network-policy-grafana.yaml
+++ b/argoproj/prometheus-operator/overlays/network-policy-grafana.yaml
@@ -14,6 +14,12 @@ spec:
         - podSelector:
             matchLabels:
               app: cloudflared
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: codex-workspace
+          podSelector:
+            matchLabels:
+              app: codex-workspace
         - ipBlock:
             cidr: 192.168.10.0/24
       ports:

--- a/docs/project_docs/BOXP-10-codex-workspace-grafana-mcp/plan.md
+++ b/docs/project_docs/BOXP-10-codex-workspace-grafana-mcp/plan.md
@@ -1,0 +1,33 @@
+# BOXP-10: Codex workspace Grafana MCP
+
+## Critique
+
+- `~/.codex/config.toml` だけを変更しても、Codex workspace Pod には Grafana service account token が注入されていない。
+- `codex-workspace` namespace の Calico NetworkPolicy は egress を制限しており、Grafana の `monitoring` namespace への TCP 3000 を明示許可する必要がある。
+- Grafana 側の Kubernetes NetworkPolicy も ingress を制限しており、`codex-workspace` Pod からの TCP 3000 を明示許可する必要がある。
+- OpenClaw は撤去済みなので、OpenClaw 由来の Secret 名や SSM path は再利用しない。
+
+## Implementation
+
+- `argoproj/codex-workspace/external-secret.yaml`
+  - `ExternalSecret/codex-workspace-grafana` を追加する。
+  - SSM Parameter Store の `/lolice/codex-workspace/grafana-service-account-token` を `Secret/codex-workspace-grafana` に同期する。
+- `argoproj/codex-workspace/deployment.yaml`
+  - `GRAFANA_URL=http://grafana.monitoring.svc.cluster.local:3000` を注入する。
+  - `GRAFANA_SERVICE_ACCOUNT_TOKEN` を `Secret/codex-workspace-grafana` から注入する。
+- `argoproj/codex-workspace/networkpolicy.yaml`
+  - Codex workspace から Grafana Pod への TCP 3000 egress を許可する。
+- `argoproj/prometheus-operator/overlays/network-policy-grafana.yaml`
+  - Grafana Pod への Codex workspace からの TCP 3000 ingress を許可する。
+- `~/.codex/config.toml`
+  - dotfiles ではなく、この workspace の home 配下だけで Grafana MCP server を登録する。
+
+## Verification
+
+- `kubectl kustomize argoproj/codex-workspace`
+- `kubectl kustomize argoproj/prometheus-operator`
+- `codex mcp list`
+
+## Manual prerequisite
+
+- Grafana service account token を SSM Parameter Store の `/lolice/codex-workspace/grafana-service-account-token` に SecureString として登録する。


### PR DESCRIPTION
## Summary

- inject `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` into the Codex workspace pod
- sync the Grafana service account token from SSM via `ExternalSecret/codex-workspace-grafana`
- allow Codex workspace egress to Grafana on TCP 3000 and allow matching Grafana ingress
- add the BOXP-10 implementation plan

## Notes

The token value itself is not committed. Before this can work in-cluster, `/lolice/codex-workspace/grafana-service-account-token` needs to exist in SSM Parameter Store as a SecureString.

## Verification

- `git diff --check`
- `/tmp/kubectl-validate kustomize argoproj/codex-workspace`
- `/tmp/kubectl-validate kustomize argoproj/prometheus-operator`
- `codex review --uncommitted`