### PR TITLE
[codex] Add etcd snapshot store manifests

### DIFF
--- a/argoproj/etcd-snapshot-store/application.yaml
+++ b/argoproj/etcd-snapshot-store/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: etcd-snapshot-store
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boxp/lolice.git
+    targetRevision: main
+    path: argoproj/etcd-snapshot-store
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: etcd-snapshots
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/argoproj/etcd-snapshot-store/deployment.yaml
+++ b/argoproj/etcd-snapshot-store/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-snapshot-store
+  namespace: etcd-snapshots
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: etcd-snapshot-store
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: etcd-snapshot-store
+    spec:
+      containers:
+      - name: snapshot-store
+        image: busybox:1.37.0
+        command: ["sh", "-c", "sleep infinity"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        volumeMounts:
+        - name: snapshots
+          mountPath: /snapshots
+      volumes:
+      - name: snapshots
+        persistentVolumeClaim:
+          claimName: etcd-snapshots

--- a/argoproj/etcd-snapshot-store/kustomization.yaml
+++ b/argoproj/etcd-snapshot-store/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- pvc.yaml
+- deployment.yaml

--- a/argoproj/etcd-snapshot-store/namespace.yaml
+++ b/argoproj/etcd-snapshot-store/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-snapshots

--- a/argoproj/etcd-snapshot-store/pvc.yaml
+++ b/argoproj/etcd-snapshot-store/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: etcd-snapshots
+  namespace: etcd-snapshots
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 10Gi

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - codex-workspace/application.yaml
 - descheduler/application.yaml
 - external-secrets-operator/application.yaml
+- etcd-snapshot-store/application.yaml
 - even-g2-lab/application.yaml
 - hitohub/overlays/prod/application.yaml
 - hitohub/overlays/stage/application.yaml

--- a/docs/project_docs/BOXP-2-etcd-snapshot-store-manifest/plan.md
+++ b/docs/project_docs/BOXP-2-etcd-snapshot-store-manifest/plan.md
@@ -1,0 +1,18 @@
+# BOXP-2 etcd snapshot store manifest plan
+
+## Context
+
+The Kubernetes upgrade workflow stores etcd snapshots in a Longhorn-backed in-cluster volume. The persistent namespace, PVC, and storage pod should be managed by lolice GitOps manifests rather than created imperatively from the arch Ansible role.
+
+## Plan
+
+- Add a new Argo CD application at `argoproj/etcd-snapshot-store`.
+- Manage namespace `etcd-snapshots`, PVC `etcd-snapshots`, and a single-replica storage Deployment.
+- Use the existing `longhorn` StorageClass with a 10Gi `ReadWriteOnce` volume.
+- Label the Deployment pods with `app.kubernetes.io/name=etcd-snapshot-store` so arch can find the ready pod by selector.
+- Add the application to the root `argoproj/kustomization.yaml`.
+
+## Validation
+
+- Build the new kustomize application.
+- Build the root `argoproj` kustomization.


### PR DESCRIPTION
## Summary

- Add a new Argo CD application for `etcd-snapshot-store`.
- Manage namespace `etcd-snapshots`, PVC `etcd-snapshots`, and a single-replica Deployment in lolice manifests.
- Use Longhorn `ReadWriteOnce` storage with a 10Gi request.
- Label the storage pod with `app.kubernetes.io/name=etcd-snapshot-store` so the arch upgrade workflow can discover it by selector.
- Add the plan at `docs/project_docs/BOXP-2-etcd-snapshot-store-manifest/plan.md`.

## Validation

- `git diff --check`
- `kubectl kustomize argoproj/etcd-snapshot-store` via `bitnami/kubectl:latest`
- `kubectl kustomize argoproj` via `bitnami/kubectl:latest`
- `codex review --uncommitted`

## Related

- Companion arch PR: https://github.com/boxp/arch/pull/9522