### PR TITLE
[codex] add obsidian sync sidecar

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -137,11 +137,7 @@ spec:
             - /bin/bash
             - -ec
             - |
-              while true; do
-                ob sync --path "${OBSIDIAN_VAULT_PATH}" --continuous || true
-                echo "obsidian-headless sync exited; retrying in 60 seconds" >&2
-                sleep 60
-              done
+              exec ob sync --path "${OBSIDIAN_VAULT_PATH}" --continuous
           env:
             - name: HOME
               value: /home/boxp

--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -130,6 +130,41 @@ spec:
               mountPath: /usr/local/bin/docker
               subPath: docker
               readOnly: true
+        - name: obsidian-sync
+          image: ghcr.io/boxp/arch/codex-workspace:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              while true; do
+                ob sync --path "${OBSIDIAN_VAULT_PATH}" --continuous || true
+                echo "obsidian-headless sync exited; retrying in 60 seconds" >&2
+                sleep 60
+              done
+          env:
+            - name: HOME
+              value: /home/boxp
+            - name: OBSIDIAN_VAULT_PATH
+              value: /home/boxp/Documents/obsidian-headless/BOXP
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - name: home
+              mountPath: /home/boxp
         - name: docker
           image: docker.io/docker:29.5.2-dind
           imagePullPolicy: IfNotPresent

--- a/docs/project_docs/obsidian-headless-sync-sidecar/plan.md
+++ b/docs/project_docs/obsidian-headless-sync-sidecar/plan.md
@@ -1,0 +1,19 @@
+# Obsidian Headless Sync Sidecar
+
+## Goal
+
+Run Obsidian Sync continuously inside the lolice Codex workspace Pod using the already installed `obsidian-headless` client.
+
+## Plan
+
+1. Add an `obsidian-sync` sidecar container to `argoproj/codex-workspace/deployment.yaml`.
+2. Reuse `ghcr.io/boxp/arch/codex-workspace:latest`, which already includes `obsidian-headless` and exposes the `ob` command.
+3. Mount the shared `/home/boxp` PVC into the sidecar so it can read the existing Obsidian headless config under `~/.config/obsidian-headless` and sync the local vault at `/home/boxp/Documents/obsidian-headless/BOXP`.
+4. Run `ob sync --path "${OBSIDIAN_VAULT_PATH}" --continuous` as UID/GID 1000 with minimal privileges.
+   If the sync process exits, retry after 60 seconds so a transient Obsidian Sync failure does not remove the workspace Pod from service.
+5. Validate the rendered Kustomize output.
+
+## Notes
+
+- The Docker image remains owned by `boxp/arch`; this change only controls runtime behavior in `boxp/lolice`.
+- Obsidian account credentials and vault encryption state remain on the workspace PVC and are not committed to Git.

--- a/docs/project_docs/obsidian-headless-sync-sidecar/plan.md
+++ b/docs/project_docs/obsidian-headless-sync-sidecar/plan.md
@@ -10,7 +10,7 @@ Run Obsidian Sync continuously inside the lolice Codex workspace Pod using the a
 2. Reuse `ghcr.io/boxp/arch/codex-workspace:latest`, which already includes `obsidian-headless` and exposes the `ob` command.
 3. Mount the shared `/home/boxp` PVC into the sidecar so it can read the existing Obsidian headless config under `~/.config/obsidian-headless` and sync the local vault at `/home/boxp/Documents/obsidian-headless/BOXP`.
 4. Run `ob sync --path "${OBSIDIAN_VAULT_PATH}" --continuous` as UID/GID 1000 with minimal privileges.
-   If the sync process exits, retry after 60 seconds so a transient Obsidian Sync failure does not remove the workspace Pod from service.
+   Let Kubernetes restart the sidecar if the continuous sync process exits unexpectedly.
 5. Validate the rendered Kustomize output.
 
 ## Notes


### PR DESCRIPTION
## Summary

- Add an `obsidian-sync` sidecar to the Codex workspace Deployment.
- Reuse the existing `ghcr.io/boxp/arch/codex-workspace:latest` image, which already includes `obsidian-headless`.
- Run `ob sync --continuous` against `/home/boxp/Documents/obsidian-headless/BOXP` using the shared `/home/boxp` PVC.
- Include the project plan under `docs/project_docs/obsidian-headless-sync-sidecar/plan.md`.

## Impact

This keeps the Obsidian vault synced from the lolice Codex workspace without coupling the sync process to the main workspace entrypoint. The sidecar retries after transient sync exits so the workspace container is not restarted for Obsidian Sync issues.

## Validation

- `git diff --check`
- `npx --yes js-yaml argoproj/codex-workspace/deployment.yaml`
- Parsed the rendered Deployment JSON and asserted the `obsidian-sync` image, vault path, shared home mount, and UID 1000 security context.

`kubectl`/`kustomize` was not available in this workspace PATH, so full Kustomize rendering was not run locally.