### PR TITLE
[codex] Add control-plane node alert

### DIFF
--- a/argoproj/prometheus-operator/control-plane-node-rules.yaml
+++ b/argoproj/prometheus-operator/control-plane-node-rules.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: control-plane-node-rules
+  namespace: monitoring
+  labels:
+    prometheus: k8s
+    role: alert-rules
+    release: prometheus
+spec:
+  groups:
+    - name: control-plane-node.rules
+      rules:
+        - alert: ControlPlaneNodeNotReady
+          expr: |
+            kube_node_status_condition{condition="Ready",status!="true"} == 1
+            and on (node)
+            kube_node_role{role=~"control-plane|master"} == 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Control-plane node is not Ready
+            description: Control-plane node {{ $labels.node }} has been NotReady or Unknown for more than 5 minutes.

--- a/argoproj/prometheus-operator/control-plane-node-rules.yaml
+++ b/argoproj/prometheus-operator/control-plane-node-rules.yaml
@@ -13,7 +13,9 @@ spec:
       rules:
         - alert: ControlPlaneNodeNotReady
           expr: |
-            kube_node_status_condition{condition="Ready",status!="true"} == 1
+            max by (node) (
+              kube_node_status_condition{condition="Ready",status!="true"} == 1
+            )
             and on (node)
             kube_node_role{role=~"control-plane|master"} == 1
           for: 5m

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - cloudflared-deployment.yaml
 - grafana-pvc.yaml
 - scrape-config.yaml
+- control-plane-node-rules.yaml
 - cloudflared-pod-monitor.yaml
 - etcd-service.yaml
 - etcd-servicemonitor.yaml

--- a/docs/project_docs/control-plane-node-alert/plan.md
+++ b/docs/project_docs/control-plane-node-alert/plan.md
@@ -8,7 +8,7 @@ Fire a node-level alert when any lolice control-plane node becomes NotReady or U
 
 1. Add a `PrometheusRule` under `argoproj/prometheus-operator`.
 2. Match control-plane nodes via `kube_node_role{role=~"control-plane|master"}` so both current and legacy Kubernetes role labels are covered.
-3. Match non-ready node state via `kube_node_status_condition{condition="Ready",status!="true"} == 1`.
+3. Match non-ready node state via `kube_node_status_condition{condition="Ready",status!="true"} == 1`, then aggregate it with `max by (node)` so the alert `for` duration survives transitions between `Ready=False` and `Ready=Unknown`.
 4. Register the new rule manifest in the prometheus-operator kustomization.
 5. Validate the manifest syntax and rendered kustomize output where local tooling allows it.
 

--- a/docs/project_docs/control-plane-node-alert/plan.md
+++ b/docs/project_docs/control-plane-node-alert/plan.md
@@ -1,0 +1,22 @@
+# Control-plane node alert
+
+## Goal
+
+Fire a node-level alert when any lolice control-plane node becomes NotReady or Unknown.
+
+## Plan
+
+1. Add a `PrometheusRule` under `argoproj/prometheus-operator`.
+2. Match control-plane nodes via `kube_node_role{role=~"control-plane|master"}` so both current and legacy Kubernetes role labels are covered.
+3. Match non-ready node state via `kube_node_status_condition{condition="Ready",status!="true"} == 1`.
+4. Register the new rule manifest in the prometheus-operator kustomization.
+5. Validate the manifest syntax and rendered kustomize output where local tooling allows it.
+
+## Verification
+
+- `npx --yes prettier --check argoproj/prometheus-operator/control-plane-node-rules.yaml docs/project_docs/control-plane-node-alert/plan.md`
+
+## Local tooling notes
+
+- `kubectl`, `kustomize`, `yq`, `yamllint`, `kubeconform`, and `ruby` were not available in the local environment.
+- `npx --yes prettier --check argoproj/prometheus-operator/kustomization.yaml` parsed the file but reported existing formatting style differences, so the existing kustomization style was left unchanged.


### PR DESCRIPTION
## Summary

- Add a node-level `PrometheusRule` for lolice control-plane nodes that are NotReady or Unknown for 5 minutes.
- Register the new rule in the prometheus-operator kustomization.
- Add the project plan under `docs/project_docs/control-plane-node-alert/plan.md`.

## Impact

Alertmanager will receive a `ControlPlaneNodeNotReady` critical alert per affected control-plane node, covering both `control-plane` and legacy `master` node roles.

## Validation

- `npx --yes prettier --check argoproj/prometheus-operator/control-plane-node-rules.yaml docs/project_docs/control-plane-node-alert/plan.md`
- `codex review --uncommitted`

## Notes

`kubectl`, `kustomize`, and `promtool` were not available in the local environment, so rendered kustomize and promtool validation were not run locally.