### PR TITLE
[codex] Add Gemini API key to Codex workspace

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -90,6 +90,11 @@ spec:
                 secretKeyRef:
                   name: codex-workspace-grafana
                   key: service-account-token
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-gemini
+                  key: GEMINI_API_KEY
             - name: DOCKER_HOST
               value: tcp://127.0.0.1:2375
             - name: DOCKER_BUILDKIT
@@ -209,6 +214,11 @@ spec:
                 secretKeyRef:
                   name: codex-workspace-grafana
                   key: service-account-token
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-gemini
+                  key: GEMINI_API_KEY
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/argoproj/codex-workspace/external-secret.yaml
+++ b/argoproj/codex-workspace/external-secret.yaml
@@ -33,3 +33,21 @@ spec:
     - secretKey: service-account-token
       remoteRef:
         key: /lolice/codex-workspace/grafana-service-account-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: codex-workspace-gemini
+  namespace: codex-workspace
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: codex-workspace-gemini
+    creationPolicy: Owner
+  data:
+    - secretKey: GEMINI_API_KEY
+      remoteRef:
+        key: /lolice/codex-workspace/gemini-api-key


### PR DESCRIPTION
## Summary

- Add a `codex-workspace-gemini` ExternalSecret backed by `/lolice/codex-workspace/gemini-api-key`.
- Inject `GEMINI_API_KEY` into the Codex workspace container.

## Why

The image-generation skill uses `GEMINI_API_KEY`. The matching SSM SecureString placeholder has been added and merged in `boxp/arch`, so the lolice manifests need to sync that parameter into the workspace pod.

## Validation

- Ran `git diff --check`.
- Verified the manifest references for `codex-workspace-gemini`, `GEMINI_API_KEY`, and `/lolice/codex-workspace/gemini-api-key`.
- Could not run `kubectl kustomize` locally because `kubectl`/`kustomize` are not installed in the current Codex workspace.

## Note

This targets the current `main` manifest shape. The local cron-workspace branch also has cron runner env injection, but `main` does not currently contain the cron runner manifests.