### PR TITLE
[codex] Deploy Even G2 main app on lolice

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/even-g2-lab.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/even-g2-lab.yaml
@@ -1,0 +1,23 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: even-g2-lab
+  namespace: argocd
+spec:
+  namespace: argocd
+  applicationRefs:
+    - namePattern: "even-g2-lab"
+      images:
+        - alias: "web"
+          imageName: "839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main:latest"
+          commonUpdateSettings:
+            updateStrategy: "newest-build"
+            pullSecret: "pullsecret:argocd/regcred"
+          manifestTargets:
+            kustomize:
+              name: "839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main"
+  writeBackConfig:
+    method: "git:secret:argocd/repo-lolice"
+    gitConfig:
+      branch: "main"
+

--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - palserver.yaml
   - ark-survival-ascended.yaml
   - ark-discord-bot.yaml
+  - even-g2-lab.yaml

--- a/argoproj/even-g2-lab/application.yaml
+++ b/argoproj/even-g2-lab/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: even-g2-lab
+  namespace: argocd
+spec:
+  destination:
+    namespace: even-g2-lab
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/boxp/lolice
+    targetRevision: main
+    path: argoproj/even-g2-lab
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+

--- a/argoproj/even-g2-lab/deployment-cloudflared.yaml
+++ b/argoproj/even-g2-lab/deployment-cloudflared.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: even-g2-lab-cloudflared
+  namespace: even-g2-lab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+        - name: cloudflared
+          image: docker.io/cloudflare/cloudflared:2026.5.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - tunnel
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+            - --protocol
+            - http2
+            - --token
+            - $(TUNNEL_TOKEN)
+          ports:
+            - name: metrics
+              containerPort: 2000
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          envFrom:
+            - secretRef:
+                name: even-g2-lab-cloudflared-secret

--- a/argoproj/even-g2-lab/deployment.yaml
+++ b/argoproj/even-g2-lab/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: even-g2-main
+  namespace: even-g2-lab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: even-g2-main
+  template:
+    metadata:
+      labels:
+        app: even-g2-main
+    spec:
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: web
+          image: 839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main:bootstrap
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+

--- a/argoproj/even-g2-lab/external-secret-cloudflared.yaml
+++ b/argoproj/even-g2-lab/external-secret-cloudflared.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-secret-even-g2-lab-cloudflared
+  namespace: even-g2-lab
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: even-g2-lab-cloudflared-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: TUNNEL_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: even-g2-lab-tunnel-token
+        metadataPolicy: None

--- a/argoproj/even-g2-lab/kustomization.yaml
+++ b/argoproj/even-g2-lab/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml
+

--- a/argoproj/even-g2-lab/kustomization.yaml
+++ b/argoproj/even-g2-lab/kustomization.yaml
@@ -3,7 +3,9 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - external-secret-cloudflared.yaml
+  - deployment-cloudflared.yaml
   - deployment.yaml
+  - service-cloudflared-metrics.yaml
   - service.yaml
   - networkpolicy.yaml
-

--- a/argoproj/even-g2-lab/namespace.yaml
+++ b/argoproj/even-g2-lab/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: even-g2-lab
+

--- a/argoproj/even-g2-lab/networkpolicy.yaml
+++ b/argoproj/even-g2-lab/networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: even-g2-main-network-policy
+  namespace: even-g2-lab
+spec:
+  selector: app == 'even-g2-main'
+  types:
+    - Ingress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      source:
+        namespaceSelector: kubernetes.io/metadata.name == 'k8s'
+        selector: app == 'cloudflared'
+      destination:
+        ports:
+          - 8080

--- a/argoproj/even-g2-lab/networkpolicy.yaml
+++ b/argoproj/even-g2-lab/networkpolicy.yaml
@@ -11,7 +11,7 @@ spec:
     - action: Allow
       protocol: TCP
       source:
-        namespaceSelector: kubernetes.io/metadata.name == 'k8s'
+        namespaceSelector: kubernetes.io/metadata.name == 'even-g2-lab'
         selector: app == 'cloudflared'
       destination:
         ports:

--- a/argoproj/even-g2-lab/service-cloudflared-metrics.yaml
+++ b/argoproj/even-g2-lab/service-cloudflared-metrics.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: even-g2-lab-cloudflared-metrics
+  namespace: even-g2-lab
+spec:
+  selector:
+    app: cloudflared
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 2000
+      targetPort: metrics
+      name: metrics

--- a/argoproj/even-g2-lab/service.yaml
+++ b/argoproj/even-g2-lab/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: even-g2-main
+  namespace: even-g2-lab
+spec:
+  type: ClusterIP
+  selector:
+    app: even-g2-main
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - codex-workspace/application.yaml
 - descheduler/application.yaml
 - external-secrets-operator/application.yaml
+- even-g2-lab/application.yaml
 - hitohub/overlays/prod/application.yaml
 - hitohub/overlays/stage/application.yaml
 - k8s-ecr-token-updater/application.yaml

--- a/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
+++ b/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
@@ -10,15 +10,17 @@
 - Namespace: `even-g2-lab`
 - Workload: nginx static image `839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main`
 - Service: `ClusterIP` `even-g2-main.even-g2-lab.svc.cluster.local:80`
-- Access path: Cloudflare private hostname route -> Gateway initial resolved IP -> k8s `cloudflared` tunnel ingress -> Kubernetes service DNS
+- Access path: Cloudflare private hostname route -> Gateway initial resolved IP -> `even-g2-lab` `cloudflared` tunnel ingress -> Kubernetes service DNS
+- Cloudflared token: ExternalSecret reads `even-g2-lab-tunnel-token` from SSM Parameter Store.
 - Image updates: Argo CD Image Updater watches ECR newest build and writes the selected tag back to `main`.
 
 ## Tasks
 
 - [x] Add `even-g2-lab` Argo CD Application.
 - [x] Add Deployment/ClusterIP Service/NetworkPolicy for main static app.
+- [x] Add dedicated `cloudflared` Deployment and ExternalSecret in `even-g2-lab`.
 - [x] Add ImageUpdater resource for ECR image updates.
 - [x] Validate YAML manifests.
 - [ ] After merge/apply, confirm `regcred` exists in `even-g2-lab` namespace.
-- [ ] Confirm k8s `cloudflared` can route `even-g2-main.b0xp.io` to `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
+- [ ] Confirm `even-g2-lab` `cloudflared` can route `even-g2-main.b0xp.io` to `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
 - [ ] After first image push, confirm ImageUpdater updates the image tag.

--- a/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
+++ b/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
@@ -1,0 +1,24 @@
+# BOXP-17: Even G2 main deployment on lolice
+
+## Goal
+
+`boxp/even-g2-lab` の main branch build を lolice cluster 上に配信し、Cloudflare WARP 経由の private hostname から Even Realities App が QR sideloading できるようにする。
+
+## Design
+
+- Application: `argoproj/even-g2-lab`
+- Namespace: `even-g2-lab`
+- Workload: nginx static image `839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main`
+- Service: `ClusterIP` `even-g2-main.even-g2-lab.svc.cluster.local:80`
+- Access path: Cloudflare Tunnel published hostname -> k8s `cloudflared` -> Kubernetes service DNS
+- Image updates: Argo CD Image Updater watches ECR newest build and writes the selected tag back to `main`.
+
+## Tasks
+
+- [x] Add `even-g2-lab` Argo CD Application.
+- [x] Add Deployment/ClusterIP Service/NetworkPolicy for main static app.
+- [x] Add ImageUpdater resource for ECR image updates.
+- [x] Validate YAML manifests.
+- [ ] After merge/apply, confirm `regcred` exists in `even-g2-lab` namespace.
+- [ ] Confirm k8s `cloudflared` can reach `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
+- [ ] After first image push, confirm ImageUpdater updates the image tag.

--- a/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
+++ b/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
@@ -10,7 +10,7 @@
 - Namespace: `even-g2-lab`
 - Workload: nginx static image `839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main`
 - Service: `ClusterIP` `even-g2-main.even-g2-lab.svc.cluster.local:80`
-- Access path: Cloudflare Tunnel published hostname -> k8s `cloudflared` -> Kubernetes service DNS
+- Access path: Cloudflare private hostname route -> Gateway initial resolved IP -> k8s `cloudflared` -> Kubernetes service DNS
 - Image updates: Argo CD Image Updater watches ECR newest build and writes the selected tag back to `main`.
 
 ## Tasks
@@ -20,5 +20,5 @@
 - [x] Add ImageUpdater resource for ECR image updates.
 - [x] Validate YAML manifests.
 - [ ] After merge/apply, confirm `regcred` exists in `even-g2-lab` namespace.
-- [ ] Confirm k8s `cloudflared` can reach `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
+- [ ] Confirm k8s `cloudflared` can resolve and reach `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
 - [ ] After first image push, confirm ImageUpdater updates the image tag.

--- a/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
+++ b/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
@@ -10,7 +10,7 @@
 - Namespace: `even-g2-lab`
 - Workload: nginx static image `839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/even-g2-client-main`
 - Service: `ClusterIP` `even-g2-main.even-g2-lab.svc.cluster.local:80`
-- Access path: Cloudflare private hostname route -> Gateway initial resolved IP -> k8s `cloudflared` -> Kubernetes service DNS
+- Access path: Cloudflare private hostname route -> Gateway initial resolved IP -> k8s `cloudflared` tunnel ingress -> Kubernetes service DNS
 - Image updates: Argo CD Image Updater watches ECR newest build and writes the selected tag back to `main`.
 
 ## Tasks
@@ -20,5 +20,5 @@
 - [x] Add ImageUpdater resource for ECR image updates.
 - [x] Validate YAML manifests.
 - [ ] After merge/apply, confirm `regcred` exists in `even-g2-lab` namespace.
-- [ ] Confirm k8s `cloudflared` can resolve and reach `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
+- [ ] Confirm k8s `cloudflared` can route `even-g2-main.b0xp.io` to `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.
 - [ ] After first image push, confirm ImageUpdater updates the image tag.


### PR DESCRIPTION
## Summary

- Add an `even-g2-lab` Argo CD application.
- Deploy the main branch G2 client image as a ClusterIP service.
- Add a dedicated `cloudflared` Deployment in the `even-g2-lab` namespace.
- Read the tunnel token from SSM Parameter Store via ExternalSecret (`even-g2-lab-tunnel-token`).
- Add Calico ingress policy allowing only the local `even-g2-lab` `cloudflared` connector to reach the app.
- Add Argo CD Image Updater config for the ECR image.
- Add/update the BOXP-17 implementation plan.

## Validation

- YAML validation for `argoproj/even-g2-lab/*.yaml`
- `git diff --cached --check`

## Notes

The initial Deployment uses a `bootstrap` image tag and will not become healthy until the first real image is pushed and Image Updater writes back the selected tag.

Cloudflare private hostname routing should send WARP/Gateway traffic for `even-g2-main.b0xp.io` through the dedicated `even-g2-lab` `cloudflared` connector, whose ingress rule forwards it to `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.

## Dependencies

- Requires the arch PR to create ECR/IAM and the dedicated Cloudflare private hostname + tunnel + SSM token.
- Requires the even-g2-lab PR to publish the ECR image from main.