### PR TITLE
Enroll Codex workspace through Cloudflare WARP

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -95,6 +95,25 @@ spec:
                 secretKeyRef:
                   name: codex-workspace-gemini
                   key: GEMINI_API_KEY
+            - name: CLOUDFLARE_WARP_ENABLED
+              value: "true"
+            - name: CLOUDFLARE_WARP_REQUIRED
+              value: "false"
+            - name: CLOUDFLARE_WARP_AUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-cloudflare-warp
+                  key: auth-client-id
+            - name: CLOUDFLARE_WARP_AUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-cloudflare-warp
+                  key: auth-client-secret
+            - name: CLOUDFLARE_WARP_ORGANIZATION
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-cloudflare-warp
+                  key: organization
             - name: DOCKER_HOST
               value: tcp://127.0.0.1:2375
             - name: DOCKER_BUILDKIT
@@ -104,7 +123,15 @@ spec:
             runAsUser: 0
             allowPrivilegeEscalation: true
             capabilities:
-              add: ["AUDIT_WRITE", "CHOWN", "FOWNER", "SETGID", "SETUID", "SYS_CHROOT"]
+              add:
+                - AUDIT_WRITE
+                - CHOWN
+                - FOWNER
+                - NET_ADMIN
+                - NET_RAW
+                - SETGID
+                - SETUID
+                - SYS_CHROOT
               drop: ["ALL"]
             readOnlyRootFilesystem: false
           resources:
@@ -135,6 +162,8 @@ spec:
               mountPath: /usr/local/bin/docker
               subPath: docker
               readOnly: true
+            - name: dev-net-tun
+              mountPath: /dev/net/tun
         - name: obsidian-sync
           image: ghcr.io/boxp/arch/codex-workspace:latest
           imagePullPolicy: Always
@@ -248,3 +277,7 @@ spec:
           emptyDir: {}
         - name: docker-graph-storage
           emptyDir: {}
+        - name: dev-net-tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice

--- a/argoproj/codex-workspace/external-secret.yaml
+++ b/argoproj/codex-workspace/external-secret.yaml
@@ -51,3 +51,27 @@ spec:
     - secretKey: GEMINI_API_KEY
       remoteRef:
         key: /lolice/codex-workspace/gemini-api-key
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: codex-workspace-cloudflare-warp
+  namespace: codex-workspace
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: codex-workspace-cloudflare-warp
+    creationPolicy: Owner
+  data:
+    - secretKey: auth-client-id
+      remoteRef:
+        key: /lolice/codex-workspace/cloudflare-warp-auth-client-id
+    - secretKey: auth-client-secret
+      remoteRef:
+        key: /lolice/codex-workspace/cloudflare-warp-auth-client-secret
+    - secretKey: organization
+      remoteRef:
+        key: /lolice/codex-workspace/cloudflare-warp-organization

--- a/argoproj/codex-workspace/networkpolicy.yaml
+++ b/argoproj/codex-workspace/networkpolicy.yaml
@@ -56,3 +56,8 @@ spec:
           - 22
           - 80
           - 443
+    - action: Allow
+      protocol: UDP
+      destination:
+        ports:
+          - 2408

--- a/docs/project_docs/BOXP-17-codex-workspace-warp-client/plan.md
+++ b/docs/project_docs/BOXP-17-codex-workspace-warp-client/plan.md
@@ -1,0 +1,16 @@
+# BOXP-17: Codex workspace WARP client
+
+Codex workspace から `even-g2-main.b0xp.io` を、`even-g2-main.even-g2-lab.svc.cluster.local` 直通ではなく Cloudflare WARP 利用者と同じ private hostname route で確認できるようにする。
+
+## Scope
+
+- workspace container に Cloudflare WARP enrollment 用 secret を注入する。
+- workspace container に `/dev/net/tun` と `NET_ADMIN` / `NET_RAW` を付与する。
+- Calico egress policy で WARP の UDP 2408 を許可する。
+- `even-g2-main` Service 側の NetworkPolicy には Codex workspace 直通許可を追加しない。
+
+## Dependencies
+
+- `boxp/arch` 側で codex-workspace image に Cloudflare WARP client と entrypoint 起動処理を追加する。
+- `boxp/arch` 側で WARP Service Token client ID / secret / organization を AWS SSM Parameter Store に用意する。
+- Cloudflare Zero Trust 側で、その Service Token を許可する device enrollment policy が必要。


### PR DESCRIPTION
## Summary

- add an ExternalSecret for Cloudflare WARP service-token enrollment values
- inject WARP env vars into the Codex workspace container
- grant the workspace container `/dev/net/tun`, `NET_ADMIN`, and `NET_RAW`
- allow UDP 2408 egress for WARP

## Context

BOXP-17 needs the Codex workspace to access `even-g2-main.b0xp.io` through the same Cloudflare WARP route used by WARP-connected users. This PR intentionally does not add a direct NetworkPolicy exception to the `even-g2-main` Service.

## Dependencies

- Requires the companion arch PR that adds the Cloudflare WARP client and entrypoint startup logic to the codex-workspace image.
- Requires Cloudflare Zero Trust device enrollment policy/service-token setup.
- Requires real SSM values for `/lolice/codex-workspace/cloudflare-warp-*`.

## Verification

- `git diff --check`

Kubernetes manifest validation was not run locally because `kubectl`/`kustomize` are not installed in this workspace. WARP connection was not tested locally because it requires the real service token and Pod TUN device.
