### PR TITLE
Allow WARP to open TUN in Codex workspace

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -119,6 +119,7 @@ spec:
             - name: DOCKER_BUILDKIT
               value: "1"
           securityContext:
+            privileged: true
             runAsNonRoot: false
             runAsUser: 0
             allowPrivilegeEscalation: true

--- a/docs/project_docs/BOXP-17-codex-workspace-warp-client/plan.md
+++ b/docs/project_docs/BOXP-17-codex-workspace-warp-client/plan.md
@@ -6,6 +6,7 @@ Codex workspace から `even-g2-main.b0xp.io` を、`even-g2-main.even-g2-lab.sv
 
 - workspace container に Cloudflare WARP enrollment 用 secret を注入する。
 - workspace container に `/dev/net/tun` と `NET_ADMIN` / `NET_RAW` を付与する。
+- rollout 後の実コンテナで `open tun: Operation not permitted` が出たため、workspace container は `privileged: true` にして TUN 作成を許可する。
 - Calico egress policy で WARP の UDP 2408 を許可する。
 - `even-g2-main` Service 側の NetworkPolicy には Codex workspace 直通許可を追加しない。
 


### PR DESCRIPTION
## Summary
- run the Codex workspace container as privileged so Cloudflare WARP can open `/dev/net/tun`
- record the runtime `open tun: Operation not permitted` finding in the BOXP-17 plan

## Verification
- `git diff --check`

## Context
After the Cloudflare enrollment policy fix in boxp/arch#9898, enrollment succeeds for the `boxp` organization and WARP fetches the private route policy. The tunnel still fails at runtime because the workspace container cannot open TUN; the effective capabilities in the running container do not include `NET_ADMIN`.