### PR TITLE
[codex] Manage codex workspace image updates

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml
@@ -1,0 +1,23 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: codex-workspace
+  namespace: argocd
+spec:
+  namespace: argocd
+  applicationRefs:
+    - namePattern: "codex-workspace"
+      images:
+        - alias: "workspace"
+          imageName: "ghcr.io/boxp/arch/codex-workspace:latest"
+          commonUpdateSettings:
+            updateStrategy: "newest-build"
+            platforms:
+              - "linux/amd64"
+          manifestTargets:
+            kustomize:
+              name: "ghcr.io/boxp/arch/codex-workspace"
+  writeBackConfig:
+    method: "git:secret:argocd/repo-lolice"
+    gitConfig:
+      branch: "main"

--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ark-survival-ascended.yaml
   - ark-discord-bot.yaml
   - even-g2-lab.yaml
+  - codex-workspace.yaml

--- a/argoproj/argocd-image-updater/overlays/configmap.yaml
+++ b/argoproj/argocd-image-updater/overlays/configmap.yaml
@@ -11,3 +11,7 @@ data:
       credentials: pullsecret:argocd/regcred
       default: true
       insecure: false
+    - name: GitHub Container Registry
+      prefix: ghcr.io
+      api_url: https://ghcr.io
+      insecure: false

--- a/docs/project_docs/codex-workspace-image-updater/plan.md
+++ b/docs/project_docs/codex-workspace-image-updater/plan.md
@@ -1,0 +1,27 @@
+# Codex workspace image updater
+
+## 背景
+
+`argoproj/codex-workspace/deployment.yaml` は `ghcr.io/boxp/arch/codex-workspace:latest` を `workspace`、`obsidian-sync`、`codex-cron-scheduler` の複数コンテナで利用している。
+
+`imagePullPolicy: Always` だけでは Deployment の Pod template が変わらないため、`latest` が更新されても既存 Pod が再作成されず、Codex workspace の Docker image 更新が反映されないことがある。
+
+## 方針
+
+- Argo CD Image Updater の CRD 管理対象に `codex-workspace` Application を追加する。
+- 他の workload と同じく、registry 上で最も新しい build tag を選ぶため、update strategy は `newest-build` にする。
+- `manifestTargets.kustomize.name` で `ghcr.io/boxp/arch/codex-workspace` を指定し、同一 image を使う複数コンテナをまとめて更新対象にする。
+- `codex-workspace` は amd64 node に固定されているため、ImageUpdater 側も `linux/amd64` を対象 platform とする。
+- `argocd-image-updater` の registry config に `ghcr.io` を明示的に追加する。
+
+## 変更対象
+
+- `argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml`
+- `argoproj/argocd-image-updater/imageupdaters/kustomization.yaml`
+- `argoproj/argocd-image-updater/overlays/configmap.yaml`
+
+## 検証
+
+- [x] Babashka + `clj-yaml` で変更 YAML の構文確認
+- [ ] `kubectl kustomize argoproj/argocd-image-updater`
+  - ローカル環境に `kubectl` / `kustomize` が無いため未実行


### PR DESCRIPTION
## Summary

- Add an Argo CD Image Updater `ImageUpdater` resource for the `codex-workspace` Application.
- Use `newest-build` so the workspace image is updated by selecting the newest registry tag, matching the existing workload pattern instead of pinning management to the mutable `latest` tag digest.
- Add `ghcr.io` to the Image Updater registry config and include the project plan document.

## Why

`argoproj/codex-workspace/deployment.yaml` uses `ghcr.io/boxp/arch/codex-workspace` in multiple containers. Relying only on `imagePullPolicy: Always` does not change the Deployment pod template, so a newly published workspace image can fail to roll out. Managing it through Argo CD Image Updater makes Git receive an image tag update and lets Argo CD reconcile the Deployment normally.

## Validation

- `bb` + `clj-yaml` YAML parse check for the changed ImageUpdater, imageupdaters kustomization, and registry ConfigMap files.
- `kubectl kustomize argoproj/argocd-image-updater` was not run locally because this environment has neither `kubectl` nor `kustomize` installed.