### PR TITLE
[codex] Fix codex workspace image updater write-back

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml
@@ -20,4 +20,5 @@ spec:
   writeBackConfig:
     method: "git:secret:argocd/repo-lolice"
     gitConfig:
+      repository: "git@github.com:boxp/lolice.git"
       branch: "main"

--- a/docs/project_docs/codex-workspace-image-updater/plan.md
+++ b/docs/project_docs/codex-workspace-image-updater/plan.md
@@ -13,6 +13,7 @@
 - `manifestTargets.kustomize.name` で `ghcr.io/boxp/arch/codex-workspace` を指定し、同一 image を使う複数コンテナをまとめて更新対象にする。
 - `codex-workspace` は amd64 node に固定されているため、ImageUpdater 側も `linux/amd64` を対象 platform とする。
 - `argocd-image-updater` の registry config に `ghcr.io` を明示的に追加する。
+- `codex-workspace` Application の `repoURL` は HTTPS だが、write-back に使う `repo-lolice` Secret は SSH key 形式のため、`gitConfig.repository` で SSH URL を明示する。
 
 ## 変更対象
 


### PR DESCRIPTION
## Summary

- Explicitly set `writeBackConfig.gitConfig.repository` to `git@github.com:boxp/lolice.git` for the `codex-workspace` ImageUpdater.
- Document why the SSH repository override is required.

## Why

The controller can select the newest workspace image tag successfully, but write-back fails with:

```text
invalid repository credentials in secret argocd/repo-lolice: does not contain githubAppID or username
```

`codex-workspace` uses an HTTPS `repoURL`, while `argocd/repo-lolice` contains `sshPrivateKey`. Without an explicit SSH repository override, Image Updater treats the secret as HTTPS credentials and expects `username/password` or GitHub App fields.

## Validation

- `bb` + `clj-yaml` YAML parse check for `argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml`.