### PR TITLE
[codex] Remove ImageUpdater spec namespace

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/ark-discord-bot.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/ark-discord-bot.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ark-discord-bot
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "ark-discord-bot"
       images:

--- a/argoproj/argocd-image-updater/imageupdaters/ark-survival-ascended.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/ark-survival-ascended.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ark-survival-ascended
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "ark-survival-ascended"
       images:

--- a/argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/codex-workspace.yaml
@@ -4,7 +4,6 @@ metadata:
   name: codex-workspace
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "codex-workspace"
       images:

--- a/argoproj/argocd-image-updater/imageupdaters/even-g2-lab.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/even-g2-lab.yaml
@@ -4,7 +4,6 @@ metadata:
   name: even-g2-lab
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "even-g2-lab"
       images:
@@ -20,4 +19,3 @@ spec:
     method: "git:secret:argocd/repo-lolice"
     gitConfig:
       branch: "main"
-

--- a/argoproj/argocd-image-updater/imageupdaters/palserver.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/palserver.yaml
@@ -4,7 +4,6 @@ metadata:
   name: palserver
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "palserver"
       images:

--- a/argoproj/argocd-image-updater/imageupdaters/prod-hitohub.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/prod-hitohub.yaml
@@ -4,7 +4,6 @@ metadata:
   name: prod-hitohub
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "prod-hitohub"
       images:

--- a/argoproj/argocd-image-updater/imageupdaters/stage-hitohub.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/stage-hitohub.yaml
@@ -4,7 +4,6 @@ metadata:
   name: stage-hitohub
   namespace: argocd
 spec:
-  namespace: argocd
   applicationRefs:
     - namePattern: "stage-hitohub"
       images:

--- a/docs/project_docs/argocd-image-updater-remove-spec-namespace/plan.md
+++ b/docs/project_docs/argocd-image-updater-remove-spec-namespace/plan.md
@@ -1,0 +1,22 @@
+# Argo CD Image Updater spec.namespace removal plan
+
+## Background
+
+Argo CD keeps showing drift for `argocd-image-updater.argoproj.io/ImageUpdater` resources because the manifests include `spec.namespace: argocd`.
+
+`namespace` is required under `metadata` to place the custom resources in the `argocd` namespace, but the `ImageUpdater` spec does not need this property.
+
+## Scope
+
+- Remove `spec.namespace` from all ImageUpdater manifests under `argoproj/argocd-image-updater/imageupdaters/`.
+- Keep `metadata.namespace: argocd` unchanged.
+- Do not change update strategies, image targets, or write-back configuration.
+
+## Validation
+
+- Confirm no ImageUpdater manifest still contains `spec.namespace`.
+- Run `kubectl kustomize argoproj/argocd-image-updater/imageupdaters` to ensure manifests still render.
+
+## Expected result
+
+Argo CD stops reporting the repeated diff that removes `spec.namespace` from ImageUpdater resources.


### PR DESCRIPTION
## Summary

Remove the unsupported `spec.namespace` property from all Argo CD Image Updater `ImageUpdater` manifests.

The resources still keep `metadata.namespace: argocd`, so they remain managed in the Argo CD namespace. Only the extra spec-level property that Argo CD keeps pruning from live state was removed.

## Root Cause

The manifests included `spec.namespace: argocd`, but the ImageUpdater spec does not need that field. Argo CD therefore continued to show drift where the live resource omitted the property.

## Impact

This should stop the repeated Argo CD diff for ImageUpdater resources without changing image update behavior, write-back configuration, or target applications.

## Validation

- `kubectl kustomize argoproj/argocd-image-updater/imageupdaters`
- Confirmed no ImageUpdater manifest still contains `spec.namespace`

## Plan

Included `docs/project_docs/argocd-image-updater-remove-spec-namespace/plan.md` in this PR.