### PR TITLE
[codex] Remove idle game applications

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - stage-hitohub.yaml
   - prod-hitohub.yaml
-  - palserver.yaml
   - ark-survival-ascended.yaml
   - ark-discord-bot.yaml
   - even-g2-lab.yaml

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -20,9 +20,6 @@ resources:
 - kubernetes-dashboard/application.yaml
 - local-volume-provisioner/application.yaml
 - longhorn/application.yaml
-- minecraft/application.yaml
-- palserver/application.yaml
-- starrupture/application.yaml
 - prometheus-operator-crd/application.yaml
 - prometheus-operator/application.yaml
 - loki/application.yaml


### PR DESCRIPTION
## Summary
- Remove minecraft, palserver, and starrupture from the root Argo CD app list.
- Stop managing the palserver image updater entry.

## Why
These idle game workloads have no running app pods but still keep Longhorn PVCs allocated. Removing them from GitOps prevents Argo CD from recreating the PVCs after the local volumes are deleted while leaving existing Longhorn remote backups intact.

## Validation
- `git diff --check`
- `kubectl kustomize argoproj`
- `kubectl kustomize argoproj/argocd-image-updater`
- `kubectl --dry-run=client apply -f /tmp/lolice-argoproj.yaml`
- `kubectl --dry-run=client apply -f /tmp/lolice-image-updater.yaml`

Note: kubectl reported the existing cluster discovery warning for `resource.k8s.io/v1`, and kustomize reported the existing `patchesStrategicMerge` deprecation warning.