### PR TITLE
[codex] Add Longhorn snapshot cleanup job

### DIFF
--- a/argoproj/longhorn/kustomization.yaml
+++ b/argoproj/longhorn/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - external-secret.yaml
   - cloudflare-deployment.yaml
   - settings.yaml
+  - recurring-jobs.yaml

--- a/argoproj/longhorn/recurring-jobs.yaml
+++ b/argoproj/longhorn/recurring-jobs.yaml
@@ -1,0 +1,15 @@
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: snapshot-cleanup
+  namespace: longhorn-system
+spec:
+  name: snapshot-cleanup
+  task: snapshot-cleanup
+  cron: "30 1 * * *"
+  groups:
+    - default
+  retain: 0
+  concurrency: 1
+  labels: {}
+  parameters: {}


### PR DESCRIPTION
## Summary
- Add a Longhorn `snapshot-cleanup` recurring job for the `default` group.
- Include the recurring job in the Longhorn kustomization.

## Why
Longhorn backup jobs create local snapshots as part of backup creation. Deleted snapshots can remain as removable/system snapshots until a purge runs. This job periodically purges removable snapshots so the cluster does not keep accumulating stale local snapshot data when the intended retention boundary is remote backups.

## Operational note
I also applied the same `snapshot-cleanup` recurring job manually and ran one manual cleanup job in-cluster. The job completed successfully with executionCount=1.

## Validation
- `git diff --check`
- `kubectl kustomize argoproj/longhorn`
- `kubectl --dry-run=client apply -f /tmp/lolice-longhorn.yaml`

Note: kubectl still reports the existing cluster discovery warning for `resource.k8s.io/v1`.