### PR TITLE
Configure GPU worker scheduling tolerations

### DIFF
--- a/argoproj/local-volume-provisioner/local-volume-provisioner.yaml
+++ b/argoproj/local-volume-provisioner/local-volume-provisioner.yaml
@@ -66,6 +66,11 @@ spec:
         app: local-volume-provisioner
     spec:
       serviceAccountName: local-storage-admin
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - image: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           name: provisioner

--- a/argoproj/longhorn/application.yaml
+++ b/argoproj/longhorn/application.yaml
@@ -17,9 +17,33 @@ spec:
             defaultReplicaCount: 2
             backupTarget: "s3://boxp-longhorn-backup@ap-northeast-1/"
             backupTargetCredentialSecret: "longhorn-backup-secret"
+            taintToleration: "lolice.io/gpu-worker=true:NoSchedule"
           global:
+            tolerations:
+              - key: lolice.io/gpu-worker
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
             storageClass:
               reclaimPolicy: "Retain"
+          longhornManager:
+            tolerations:
+              - key: lolice.io/gpu-worker
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
+          longhornDriver:
+            tolerations:
+              - key: lolice.io/gpu-worker
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
+          longhornUI:
+            tolerations:
+              - key: lolice.io/gpu-worker
+                operator: Equal
+                value: "true"
+                effect: NoSchedule
           metrics:
             serviceMonitor:
               enabled: true

--- a/argoproj/prometheus-operator/cloudflared-deployment.yaml
+++ b/argoproj/prometheus-operator/cloudflared-deployment.yaml
@@ -12,6 +12,11 @@ spec:
       labels:
         app: cloudflared
     spec:
+      tolerations:
+      - key: lolice.io/gpu-worker
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2026.6.1

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -23,6 +23,7 @@ patchesStrategicMerge:
 - overlays/alertmanager.yaml
 - overlays/prometheus.yaml
 - overlays/grafana.yaml
+- overlays/monitoring-deployment-tolerations.yaml
 - overlays/grafana-config.yaml
 patchesJson6902:
 - target:

--- a/argoproj/prometheus-operator/overlays/alertmanager.yaml
+++ b/argoproj/prometheus-operator/overlays/alertmanager.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  tolerations:
+    - key: lolice.io/gpu-worker
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
   storage:
     volumeClaimTemplate:
       spec:
@@ -14,4 +19,3 @@ spec:
           requests:
             storage: 1Gi
         storageClassName: longhorn
-

--- a/argoproj/prometheus-operator/overlays/grafana.yaml
+++ b/argoproj/prometheus-operator/overlays/grafana.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   template:
     spec:
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - name: grafana
           resources:

--- a/argoproj/prometheus-operator/overlays/monitoring-deployment-tolerations.yaml
+++ b/argoproj/prometheus-operator/overlays/monitoring-deployment-tolerations.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-operator
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule

--- a/argoproj/prometheus-operator/overlays/prometheus.yaml
+++ b/argoproj/prometheus-operator/overlays/prometheus.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   replicas: 1
   retention: 31d
+  tolerations:
+    - key: lolice.io/gpu-worker
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
   enableFeatures:
     - otlp-write-receiver
   resources:


### PR DESCRIPTION
## Summary

- Add `lolice.io/gpu-worker=true:NoSchedule` tolerations for Longhorn components and Longhorn system-managed workloads.
- Add the same toleration to kube-prometheus components that should remain schedulable on GPU worker nodes.
- Add the toleration to the local-volume-provisioner DaemonSet.

## Context

`golyat-4` is tainted as a GPU worker node. General workloads should not move there, but essential node-local or cluster observability/storage workloads must continue to run there.

## Validation

- `kubectl kustomize argoproj/prometheus-operator`
- `kubectl kustomize argoproj/local-volume-provisioner`
- changed YAML parse check
- `git diff --check`

Note: full repository YAML parse still hits an existing tab in `argoproj/hitohub/overlays/stage/external-secret-hitohub.yaml`, unrelated to this change.
