### PR TITLE
Restrict dashboard workloads from GPU workers

### DIFF
--- a/argoproj/longhorn/application.yaml
+++ b/argoproj/longhorn/application.yaml
@@ -19,11 +19,6 @@ spec:
             backupTargetCredentialSecret: "longhorn-backup-secret"
             taintToleration: "lolice.io/gpu-worker=true:NoSchedule"
           global:
-            tolerations:
-              - key: lolice.io/gpu-worker
-                operator: Equal
-                value: "true"
-                effect: NoSchedule
             storageClass:
               reclaimPolicy: "Retain"
           longhornManager:
@@ -33,12 +28,6 @@ spec:
                 value: "true"
                 effect: NoSchedule
           longhornDriver:
-            tolerations:
-              - key: lolice.io/gpu-worker
-                operator: Equal
-                value: "true"
-                effect: NoSchedule
-          longhornUI:
             tolerations:
               - key: lolice.io/gpu-worker
                 operator: Equal

--- a/argoproj/prometheus-operator/cloudflared-deployment.yaml
+++ b/argoproj/prometheus-operator/cloudflared-deployment.yaml
@@ -12,11 +12,6 @@ spec:
       labels:
         app: cloudflared
     spec:
-      tolerations:
-      - key: lolice.io/gpu-worker
-        operator: Equal
-        value: "true"
-        effect: NoSchedule
       containers:
       - name: cloudflared
         image: docker.io/cloudflare/cloudflared:2026.6.1

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -24,6 +24,7 @@ patchesStrategicMerge:
 - overlays/prometheus.yaml
 - overlays/grafana.yaml
 - overlays/monitoring-deployment-tolerations.yaml
+- overlays/dashboard-placement.yaml
 - overlays/grafana-config.yaml
 patchesJson6902:
 - target:

--- a/argoproj/prometheus-operator/overlays/dashboard-placement.yaml
+++ b/argoproj/prometheus-operator/overlays/dashboard-placement.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: lolice.io/gpu-worker
+                    operator: DoesNotExist
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: lolice.io/gpu-worker
+                    operator: DoesNotExist

--- a/argoproj/prometheus-operator/overlays/grafana.yaml
+++ b/argoproj/prometheus-operator/overlays/grafana.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   template:
     spec:
-      tolerations:
-        - key: lolice.io/gpu-worker
-          operator: Equal
-          value: "true"
-          effect: NoSchedule
       containers:
         - name: grafana
           resources:


### PR DESCRIPTION
## Summary

- Keep GPU worker tolerations for essential monitoring/storage components.
- Remove GPU worker tolerations from dashboard/access workloads: Grafana, monitoring cloudflared, and Longhorn UI.
- Add required node affinity so Grafana and monitoring cloudflared avoid nodes labeled `lolice.io/gpu-worker`.

## Policy

Allowed on GPU workers:
- Prometheus / Alertmanager
- exporters and metrics adapters
- Grafana Alloy / log collection
- Longhorn manager, driver, and system-managed components
- local-volume-provisioner

Not allowed on GPU workers:
- Grafana dashboard workload
- monitoring cloudflared access tunnel
- Longhorn UI

## Validation

- `kubectl kustomize argoproj/prometheus-operator`
- changed YAML parse check
- `git diff --check`
