### PR TITLE
Set Longhorn kubelet root dir

### DIFF
--- a/argoproj/longhorn/application.yaml
+++ b/argoproj/longhorn/application.yaml
@@ -13,6 +13,8 @@ spec:
         values: |
           preUpgradeChecker:
             jobEnabled: false
+          csi:
+            kubeletRootDir: /var/lib/kubelet
           defaultSettings:
             defaultReplicaCount: 2
             backupTarget: "s3://boxp-longhorn-backup@ap-northeast-1/"


### PR DESCRIPTION
## Summary

- Set `csi.kubeletRootDir: /var/lib/kubelet` in the Longhorn Helm values.

## Context

After syncing the GPU worker toleration changes, `longhorn-driver-deployer` on `golyat-4` crashed while trying to auto-detect kubelet root dir through the temporary `discover-proc-kubelet-cmdline` pod.

The pod log reported:

```text
Need to specify "--kubelet-root-dir" in your Longhorn deployment yaml.
```

The cluster uses the standard kubelet root directory, so make it explicit instead of relying on auto-detection.

## Validation

- parsed `argoproj/longhorn/application.yaml`
- `git diff --check`
