### PR TITLE
Add Intel GPU device plugin manifests

### DIFF
--- a/argoproj/intel-gpu-device-plugin/application.yaml
+++ b/argoproj/intel-gpu-device-plugin/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: intel-gpu-device-plugin
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    path: argoproj/intel-gpu-device-plugin
+    repoURL: https://github.com/boxp/lolice
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: intel-device-plugins
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argoproj/intel-gpu-device-plugin/daemonset.yaml
+++ b/argoproj/intel-gpu-device-plugin/daemonset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-plugin
+  labels:
+    app: intel-gpu-plugin
+spec:
+  selector:
+    matchLabels:
+      app: intel-gpu-plugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: intel-gpu-plugin
+    spec:
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      containers:
+        - name: intel-gpu-plugin
+          image: intel/intel-gpu-plugin:0.36.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -enable-monitoring
+            - -v=2
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          securityContext:
+            seLinuxOptions:
+              type: container_device_plugin_t
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              memory: 45Mi
+              cpu: 40m
+            limits:
+              memory: 90Mi
+              cpu: 100m
+          volumeMounts:
+            - name: devfs
+              mountPath: /dev/dri
+              readOnly: true
+            - name: sysfsdrm
+              mountPath: /sys/class/drm
+              readOnly: true
+            - name: kubeletsockets
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: cdipath
+              mountPath: /var/run/cdi
+      volumes:
+        - name: devfs
+          hostPath:
+            path: /dev/dri
+        - name: sysfsdrm
+          hostPath:
+            path: /sys/class/drm
+        - name: kubeletsockets
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: cdipath
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate

--- a/argoproj/intel-gpu-device-plugin/kustomization.yaml
+++ b/argoproj/intel-gpu-device-plugin/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: intel-device-plugins
+
+resources:
+  - namespace.yaml
+  - node-feature-rules.yaml
+  - daemonset.yaml

--- a/argoproj/intel-gpu-device-plugin/namespace.yaml
+++ b/argoproj/intel-gpu-device-plugin/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel-device-plugins

--- a/argoproj/intel-gpu-device-plugin/node-feature-rules.yaml
+++ b/argoproj/intel-gpu-device-plugin/node-feature-rules.yaml
@@ -1,0 +1,91 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-gpu-device
+spec:
+  rules:
+    - name: intel.gpu
+      labels:
+        intel.feature.node.kubernetes.io/gpu: "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor:
+              op: In
+              value:
+                - "8086"
+            class:
+              op: In
+              value:
+                - "0300"
+                - "0380"
+      matchAny:
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                i915:
+                  op: Exists
+        - matchFeatures:
+            - feature: kernel.enabledmodule
+              matchExpressions:
+                i915:
+                  op: Exists
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                xe:
+                  op: Exists
+        - matchFeatures:
+            - feature: kernel.enabledmodule
+              matchExpressions:
+                xe:
+                  op: Exists
+---
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-gpu-platform-labeling
+spec:
+  rules:
+    - name: intel.gpu.generic.deviceid
+      labelsTemplate: |
+        {{ range .pci.device }}gpu.intel.com/device-id.{{ .class }}-{{ .device }}.present=true
+        {{ end }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor:
+              op: In
+              value:
+                - "8086"
+            class:
+              op: In
+              value:
+                - "0300"
+                - "0380"
+    - name: intel.gpu.generic.count.0300
+      labelsTemplate: gpu.intel.com/device-id.0300-{{ (index .pci.device 0).device }}.count={{ len .pci.device }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor:
+              op: In
+              value:
+                - "8086"
+            class:
+              op: In
+              value:
+                - "0300"
+    - name: intel.gpu.generic.count.0380
+      labelsTemplate: gpu.intel.com/device-id.0380-{{ (index .pci.device 0).device }}.count={{ len .pci.device }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor:
+              op: In
+              value:
+                - "8086"
+            class:
+              op: In
+              value:
+                - "0380"

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
 - kubernetes-dashboard/application.yaml
 - local-volume-provisioner/application.yaml
 - longhorn/application.yaml
+- node-feature-discovery/application.yaml
+- intel-gpu-device-plugin/application.yaml
 - prometheus-operator-crd/application.yaml
 - prometheus-operator/application.yaml
 - loki/application.yaml

--- a/argoproj/node-feature-discovery/application.yaml
+++ b/argoproj/node-feature-discovery/application.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: node-feature-discovery
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    targetRevision: 0.18.3
+    chart: node-feature-discovery
+    helm:
+      values: |
+        worker:
+          tolerations:
+            - key: lolice.io/gpu-worker
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: node-feature-discovery
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary
- add node-feature-discovery as an Argo CD Helm application
- add Intel GPU device plugin manifests with NodeFeatureRules and a GPU-worker toleration
- keep dashboard workloads off the GPU worker while allowing monitoring/exporter/log collection workloads

## Notes
- uses the static Intel GPU plugin DaemonSet instead of the Intel operator because the current cluster does not have cert-manager CRDs installed
- the plugin targets nodes labeled `intel.feature.node.kubernetes.io/gpu=true` and tolerates `lolice.io/gpu-worker=true:NoSchedule`

## Validation
- `kubectl kustomize argoproj/intel-gpu-device-plugin`
- `kubectl kustomize argoproj`
- YAML parse for changed manifests
- `git diff --check`