### PR TITLE
Restrict Intel GPU plugin to GPU workers

### DIFF
--- a/argoproj/intel-gpu-device-plugin/daemonset.yaml
+++ b/argoproj/intel-gpu-device-plugin/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       nodeSelector:
         intel.feature.node.kubernetes.io/gpu: "true"
+        lolice.io/gpu-worker: "true"
       tolerations:
         - key: lolice.io/gpu-worker
           operator: Equal


### PR DESCRIPTION
## Summary
- require `lolice.io/gpu-worker=true` in the Intel GPU plugin DaemonSet node selector
- keep NFD cluster-wide, but prevent the device plugin from landing on non-GPU-worker Intel GPU nodes

## Validation
- `kubectl kustomize argoproj/intel-gpu-device-plugin`
- `kubectl kustomize argoproj`
- YAML parse for the changed DaemonSet
- `git diff --check`