### PR TITLE
Add local LLM SYCL workload

### DIFF
--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - k8s/application.yaml
 - kubernetes-dashboard/application.yaml
 - local-volume-provisioner/application.yaml
+- local-llm/application.yaml
 - longhorn/application.yaml
 - node-feature-discovery/application.yaml
 - intel-gpu-device-plugin/application.yaml

--- a/argoproj/local-llm/application.yaml
+++ b/argoproj/local-llm/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: local-llm
+  namespace: argocd
+spec:
+  destination:
+    namespace: local-llm
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: argoproj/local-llm
+    repoURL: https://github.com/boxp/lolice
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: llama-server
+  template:
+    metadata:
+      labels:
+        app: llama-server
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        lolice.io/gpu-worker: "true"
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+        supplementalGroups:
+          - 44
+          - 110
+      initContainers:
+        - name: fetch-smoke-model
+          image: docker.io/curlimages/curl:8.21.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              model=/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+              if [ ! -s "${model}" ]; then
+                tmp="${model}.part"
+                rm -f "${tmp}"
+                curl -L --fail --retry 5 --retry-all-errors \
+                  -o "${tmp}" \
+                  https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+                mv "${tmp}" "${model}"
+              fi
+              chown 1000:1000 "${model}"
+              chmod 0644 "${model}"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["CHOWN", "FOWNER"]
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            - name: tmp
+              mountPath: /tmp
+      containers:
+        - name: llama-server
+          image: ghcr.io/boxp/arch/llama-sycl:latest
+          imagePullPolicy: Always
+          args:
+            - llama-server
+            - -m
+            - /models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8080"
+            - -dev
+            - SYCL0
+            - -ngl
+            - "99"
+            - -c
+            - "1024"
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: ONEAPI_DEVICE_SELECTOR
+              value: level_zero:0
+            - name: ZES_ENABLE_SYSMAN
+              value: "1"
+            - name: HOME
+              value: /tmp
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+              gpu.intel.com/i915: "1"
+            limits:
+              cpu: "8"
+              memory: 16Gi
+              gpu.intel.com/i915: "1"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: local-llm-models
+        - name: tmp
+          emptyDir: {}

--- a/argoproj/local-llm/kustomization.yaml
+++ b/argoproj/local-llm/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: local-llm
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/argoproj/local-llm/namespace.yaml
+++ b/argoproj/local-llm/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-llm

--- a/argoproj/local-llm/pvc.yaml
+++ b/argoproj/local-llm/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-llm-models
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/argoproj/local-llm/service.yaml
+++ b/argoproj/local-llm/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-server
+spec:
+  type: ClusterIP
+  selector:
+    app: llama-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/docs/project_docs/BOXP-23-local-llm-sycl/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-sycl/plan.md
@@ -1,0 +1,23 @@
+# BOXP-23 local LLM SYCL workload plan
+
+## Context
+
+`golyat-4` is the dedicated Intel GPU worker. It is labeled `lolice.io/gpu-worker=true`, tainted `lolice.io/gpu-worker=true:NoSchedule`, and exposes `gpu.intel.com/i915=1` through the Intel GPU device plugin.
+
+## Plan
+
+1. Consume `ghcr.io/boxp/arch/llama-sycl`, built from `TheTom/llama-cpp-turboquant` `feature/turboquant-kv-cache`.
+2. Add a `local-llm` Argo CD Application.
+3. Add a `llama-server` Deployment that:
+   - requests `gpu.intel.com/i915: 1`
+   - selects `lolice.io/gpu-worker=true`
+   - tolerates `lolice.io/gpu-worker=true:NoSchedule`
+   - exposes an internal ClusterIP service
+4. Use a small TinyLlama GGUF and a 5Gi Longhorn PVC for the first Kubernetes smoke.
+5. After the GHCR image exists, verify `/health`, `/v1/models`, `/v1/chat/completions`, and GPU offload logs.
+
+## Follow-up
+
+- Replace the smoke model setup with the selected production model storage layout.
+- Add router preset for `gemma4-26b` first.
+- Add `ornith-35b` after router/output behavior is verified.


### PR DESCRIPTION
## Summary

Add the initial `local-llm` GitOps application for the `golyat-4` Intel GPU worker.

- consumes `ghcr.io/boxp/arch/llama-sycl:latest`
- requests `gpu.intel.com/i915: 1`
- selects `lolice.io/gpu-worker=true`
- tolerates `lolice.io/gpu-worker=true:NoSchedule`
- downloads a small TinyLlama GGUF to a Longhorn PVC for the first Kubernetes smoke
- exposes `llama-server` internally with a ClusterIP Service

This is draft until `boxp/arch#10613` builds and publishes the GHCR image.

## Dependency

- Requires `boxp/arch#10613` to merge and publish `ghcr.io/boxp/arch/llama-sycl`.

## Verification

- `kubectl kustomize argoproj/local-llm`
- `kubectl kustomize argoproj`
- `kubectl apply --dry-run=server -f /tmp/local-llm-rendered.yaml` after creating a temporary `local-llm` namespace
- `kubectl apply --dry-run=server -f argoproj/local-llm/application.yaml`

Prior runtime evidence:

- Temporary Kubernetes Job on `golyat-4` requesting `gpu.intel.com/i915: 1` built and ran SYCL `llama-server` in a container.
- The smoke returned `/health`, `/v1/chat/completions`, and logged `offloaded 23/23 layers to GPU`.
- Host TurboQuant SYCL smoke passed with `TheTom/llama-cpp-turboquant` `feature/turboquant-kv-cache` commit `a33ef00b13476e9c609caecc3c1c015b8615011d`.
