### PR TITLE
Add local LLM image updater

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ark-discord-bot.yaml
   - even-g2-lab.yaml
   - codex-workspace.yaml
+  - local-llm.yaml

--- a/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
@@ -1,0 +1,23 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: local-llm
+  namespace: argocd
+spec:
+  applicationRefs:
+    - namePattern: "local-llm"
+      images:
+        - alias: "llama-sycl"
+          imageName: "ghcr.io/boxp/arch/llama-sycl:latest"
+          commonUpdateSettings:
+            updateStrategy: "newest-build"
+            platforms:
+              - "linux/amd64"
+          manifestTargets:
+            kustomize:
+              name: "ghcr.io/boxp/arch/llama-sycl"
+  writeBackConfig:
+    method: "git:secret:argocd/repo-lolice"
+    gitConfig:
+      repository: "git@github.com:boxp/lolice.git"
+      branch: "main"

--- a/docs/project_docs/BOXP-23-local-llm-image-updater/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-image-updater/plan.md
@@ -1,0 +1,17 @@
+# Plan: local-llm ImageUpdater
+
+## Context
+
+`local-llm` consumes `ghcr.io/boxp/arch/llama-sycl:latest`. The repository convention is to let Argo CD Image Updater write the resolved image update back to `boxp/lolice` instead of manually restarting workloads to pick up `latest`.
+
+## Change
+
+- Add an `ImageUpdater` for the `local-llm` Application.
+- Track `ghcr.io/boxp/arch/llama-sycl:latest` with `newest-build` for `linux/amd64`.
+- Use the existing `git:secret:argocd/repo-lolice` write-back method targeting `main`.
+
+## Verification
+
+- Render `argoproj/argocd-image-updater` with `kubectl kustomize`.
+- Server dry-run the rendered manifests.
+- Sync `argocd-image-updater`, then let Image Updater update `local-llm` image state.


### PR DESCRIPTION
## Summary
- add ImageUpdater for local-llm / ghcr.io/boxp/arch/llama-sycl:latest
- use existing git write-back configuration for boxp/lolice main
- include project plan for the image updater change

## Test
- kubectl kustomize argoproj/argocd-image-updater >/tmp/argocd-image-updater-local-llm.yaml
- kubectl apply --dry-run=server -f /tmp/argocd-image-updater-local-llm.yaml