### PR TITLE
Use digest tracking for local LLM image

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
@@ -10,7 +10,7 @@ spec:
         - alias: "llama-sycl"
           imageName: "ghcr.io/boxp/arch/llama-sycl:latest"
           commonUpdateSettings:
-            updateStrategy: "newest-build"
+            updateStrategy: "digest"
             platforms:
               - "linux/amd64"
           manifestTargets:

--- a/argoproj/local-llm/.argocd-source-local-llm.yaml
+++ b/argoproj/local-llm/.argocd-source-local-llm.yaml
@@ -1,3 +1,3 @@
 kustomize:
   images:
-  - ghcr.io/boxp/arch/llama-sycl=ghcr.io/boxp/arch/llama-sycl:sha-87fdeb8
+  - ghcr.io/boxp/arch/llama-sycl=ghcr.io/boxp/arch/llama-sycl:latest@sha256:433b7455e86da269f9668a81d407a4b4e0d454daee2be52b491aca4af25881e0

--- a/docs/project_docs/BOXP-23-local-llm-image-updater/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-image-updater/plan.md
@@ -7,8 +7,9 @@
 ## Change
 
 - Add an `ImageUpdater` for the `local-llm` Application.
-- Track `ghcr.io/boxp/arch/llama-sycl:latest` with `newest-build` for `linux/amd64`.
+- Track `ghcr.io/boxp/arch/llama-sycl:latest` with `digest` for `linux/amd64`.
 - Use the existing `git:secret:argocd/repo-lolice` write-back method targeting `main`.
+- Keep the generated `.argocd-source-local-llm.yaml` on the current `latest` digest. `newest-build` selected the older `sha-87fdeb8` tag from GHCR, so digest tracking is required for this `latest`-driven image.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- switch local-llm ImageUpdater from newest-build to digest tracking
- replace the stale sha-87fdeb8 Argo source override with the current latest digest
- document why digest tracking is required for this image

## Verification
- kubectl kustomize argoproj/argocd-image-updater >/tmp/argocd-image-updater-local-llm-digest.yaml
- kubectl apply --dry-run=server -f /tmp/argocd-image-updater-local-llm-digest.yaml
- kubectl kustomize argoproj/local-llm >/tmp/local-llm-source-digest.yaml
- kubectl apply --dry-run=server -f /tmp/local-llm-source-digest.yaml
- git diff --check