### PR TITLE
Enable flash attention for local LLM

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -51,6 +51,8 @@ spec:
             - q8_0
             - --cache-type-v
             - turbo3
+            - -fa
+            - "on"
             - --no-warmup
           ports:
             - name: http

--- a/docs/project_docs/BOXP-23-local-llm-flash-attn/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-flash-attn/plan.md
@@ -1,0 +1,22 @@
+# Plan: local-llm Flash Attention
+
+## Context
+
+`local-llm` runs Gemma4 on `golyat-4` with `--cache-type-v turbo3`. After moving the image to the `cclecle` SYCL `SET_ROWS` source ref, the original abort changed to a Flash Attention failure:
+
+- `quantized V cache was requested, but this requires Flash Attention`
+- `Flash Attention was auto, set to disabled`
+- process exited with code 139
+
+A one-off pod using the same GPU worker security context started successfully with `--cache-type-v turbo3 -fa on`; `/health`, `/v1/models`, and a short chat completion returned over the pod IP from `golyat-4`.
+
+## Change
+
+- Explicitly pass `-fa on` for the `local-llm` `llama-server` container.
+- Keep `turbo3` V cache enabled.
+
+## Verification
+
+- Render `argoproj/local-llm` with `kubectl kustomize`.
+- Server dry-run the rendered manifest.
+- Smoke-tested one-off `llama-fa-test` pod on `golyat-4` with the same args plus `-fa on`.


### PR DESCRIPTION
## Summary
- add `-fa on` to local-llm llama-server args
- keep turbo3 V cache enabled
- document the runtime finding from the golyat-4 smoke test

## Verification
- kubectl kustomize argoproj/local-llm >/tmp/local-llm-flash-attn.yaml
- kubectl apply --dry-run=server -f /tmp/local-llm-flash-attn.yaml
- one-off llama-fa-test pod on golyat-4 returned /health, /v1/models, and a short chat completion with turbo3 + -fa on