### PR TITLE
feat(local-llm): add Gemma4 router alias

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -33,14 +33,17 @@ spec:
           imagePullPolicy: Always
           args:
             - llama-server
-            - -m
-            - /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
             - --host
             - 0.0.0.0
             - --port
             - "8080"
             - -dev
             - SYCL0
+            - --models-preset
+            - /config/models.ini
+            - --models-max
+            - "1"
+            - --no-models-autoload
             - -ngl
             - "3"
             - -c
@@ -111,6 +114,10 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            - name: models-config
+              mountPath: /config/models.ini
+              subPath: models.ini
+              readOnly: true
       volumes:
         - name: models
           hostPath:
@@ -118,3 +125,6 @@ spec:
             type: Directory
         - name: tmp
           emptyDir: {}
+        - name: models-config
+          configMap:
+            name: llama-server-models

--- a/argoproj/local-llm/kustomization.yaml
+++ b/argoproj/local-llm/kustomization.yaml
@@ -4,5 +4,6 @@ namespace: local-llm
 
 resources:
   - namespace.yaml
+  - models-config.yaml
   - deployment.yaml
   - service.yaml

--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llama-server-models
+data:
+  models.ini: |
+    version = 1
+
+    [gemma4-26b]
+    model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
+    load-on-startup = true

--- a/docs/project_docs/BOXP-23-local-llm-router-ngl3/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-router-ngl3/plan.md
@@ -1,0 +1,23 @@
+# BOXP-23 local-llm router NGL3
+
+## 背景
+
+`boxp/lolice#632` で Gemma4 single-model deployment は `-ngl 3` に固定され、`turbo3` を維持したまま `Return exactly: OK` が通る状態になった。
+
+Phase 6 の次段階では、Ooedo と同じ model alias `gemma4-26b` を使えるようにする必要がある。`codex-workspace` / pi agent 統合でも filename ではなく stable alias を使う。
+
+## 変更方針
+
+- `models.ini` を ConfigMap として追加する。
+- `[gemma4-26b]` に hostPath 上の Gemma4 GGUF を登録する。
+- `load-on-startup = true` で起動時に Gemma4 をloadする。
+- Deployment は `-m` 直指定をやめ、`--models-preset /config/models.ini --models-max 1 --no-models-autoload` を使う。
+- `-ngl 3 --cache-type-v turbo3 -fa on --jinja --reasoning off --cpu-moe` は維持する。
+- image digest は `argocd-image-updater` 管理のままにし、このPRでは触らない。
+
+## 検証
+
+- `kubectl kustomize argoproj/local-llm`
+- `kubectl apply --dry-run=server`
+- Argo CD sync 後に `/v1/models` で `gemma4-26b` が `loaded` になることを確認する。
+- `/v1/chat/completions` に `model: gemma4-26b` を指定して `OK` が返ることを確認する。


### PR DESCRIPTION
## Summary
- add a `models.ini` ConfigMap for `gemma4-26b`
- switch local-llm from direct `-m` loading to `--models-preset` router mode
- keep verified `-ngl 3`, `turbo3`, `-fa on`, `--jinja`, `--reasoning off`, and `--cpu-moe` settings

## Validation
- `kubectl kustomize argoproj/local-llm >/tmp/local-llm-router-ngl3.yaml`
- `kubectl apply --dry-run=server -f /tmp/local-llm-router-ngl3.yaml`

## Notes
- image digest remains managed by argocd-image-updater
