### PR TITLE
feat(codex-workspace): configure local LLM pi provider

### DIFF
--- a/argoproj/codex-workspace/configmap.yaml
+++ b/argoproj/codex-workspace/configmap.yaml
@@ -16,3 +16,40 @@ data:
     ClientAliveInterval 60
     ClientAliveCountMax 3
     Subsystem sftp /usr/lib/openssh/sftp-server
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: codex-workspace-pi-config
+  namespace: codex-workspace
+data:
+  models.json: |
+    {
+      "providers": {
+        "llama.cpp": {
+          "baseUrl": "http://llama-server.local-llm.svc.cluster.local:8080/v1",
+          "api": "openai-completions",
+          "apiKey": "local-llm",
+          "compat": {
+            "supportsDeveloperRole": false,
+            "supportsReasoningEffort": false
+          },
+          "models": [
+            {
+              "id": "gemma4-26b",
+              "name": "Gemma4 26B local",
+              "reasoning": false,
+              "input": ["text"],
+              "contextWindow": 4096,
+              "maxTokens": 4096,
+              "cost": {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0
+              }
+            }
+          ]
+        }
+      }
+    }

--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - -ec
             - |
               mkdir -p /home/boxp/.ssh
+              mkdir -p /home/boxp/.pi/agent
               curl -fsSL https://github.com/boxp.keys -o /home/boxp/.ssh/authorized_keys
               test -s /home/boxp/.ssh/authorized_keys
               chown -R 1000:1000 /home/boxp/.ssh
@@ -155,6 +156,10 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
+            - name: pi-config
+              mountPath: /home/boxp/.pi/agent/models.json
+              subPath: models.json
+              readOnly: true
             - name: sshd-config
               mountPath: /etc/ssh/sshd_config
               subPath: sshd_config
@@ -274,6 +279,9 @@ spec:
         - name: sshd-config
           configMap:
             name: codex-workspace-sshd-config
+        - name: pi-config
+          configMap:
+            name: codex-workspace-pi-config
         - name: docker-cli
           emptyDir: {}
         - name: docker-graph-storage

--- a/argoproj/codex-workspace/networkpolicy.yaml
+++ b/argoproj/codex-workspace/networkpolicy.yaml
@@ -52,6 +52,13 @@ spec:
     - action: Allow
       protocol: TCP
       destination:
+        selector: app == 'llama-server'
+        namespaceSelector: kubernetes.io/metadata.name == 'local-llm'
+        ports:
+          - 8080
+    - action: Allow
+      protocol: TCP
+      destination:
         ports:
           - 22
           - 80

--- a/docs/project_docs/BOXP-23-codex-workspace-local-llm-pi/plan.md
+++ b/docs/project_docs/BOXP-23-codex-workspace-local-llm-pi/plan.md
@@ -1,0 +1,23 @@
+# BOXP-23 codex-workspace local LLM pi config
+
+## Background
+
+`local-llm` now exposes a verified `gemma4-26b` alias through `llama-server.local-llm.svc.cluster.local:8080`.
+
+The Phase 6 end state requires the existing `codex-workspace` Pod to use this local LLM through pi agent. The current NetworkPolicy blocks egress to `local-llm`, and `~/.pi/agent/models.json` is not managed by GitOps.
+
+## Plan
+
+- Add `codex-workspace-pi-config` ConfigMap with `models.json`.
+- Mount the config to `/home/boxp/.pi/agent/models.json` in the `workspace` container.
+- Allow egress from `codex-workspace` to `local-llm` pods on TCP 8080.
+- Keep image digest updates under the existing `argocd-image-updater` flow.
+
+## Validation
+
+- `kubectl kustomize argoproj/codex-workspace`
+- `kubectl apply --dry-run=server`
+- After the `codex-workspace` image contains `pi`, verify:
+  - `curl http://llama-server.local-llm.svc.cluster.local:8080/health`
+  - `pi --version`
+  - `pi` can call `gemma4-26b` and return `OK`


### PR DESCRIPTION
## Summary
- add a pi `models.json` ConfigMap for the local `gemma4-26b` provider
- mount the pi config into the workspace container
- allow codex-workspace egress to local-llm on TCP 8080

## Validation
- `kubectl kustomize argoproj/codex-workspace >/tmp/codex-workspace-pi.yaml`
- `kubectl apply --dry-run=server -f /tmp/codex-workspace-pi.yaml`

## Notes
- the codex-workspace image still needs the paired boxp/arch pi-agent image update before `pi` CLI smoke can pass
- image digest remains managed by argocd-image-updater
