### PR TITLE
fix(codex-workspace): set pi config directory

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -96,6 +96,8 @@ spec:
                 secretKeyRef:
                   name: codex-workspace-gemini
                   key: GEMINI_API_KEY
+            - name: PI_CODING_AGENT_DIR
+              value: /home/boxp/.pi/agent
             - name: CLOUDFLARE_WARP_ENABLED
               value: "true"
             - name: CLOUDFLARE_WARP_REQUIRED

--- a/docs/project_docs/BOXP-23-codex-workspace-local-llm-pi/plan.md
+++ b/docs/project_docs/BOXP-23-codex-workspace-local-llm-pi/plan.md
@@ -10,6 +10,7 @@ The Phase 6 end state requires the existing `codex-workspace` Pod to use this lo
 
 - Add `codex-workspace-pi-config` ConfigMap with `models.json`.
 - Mount the config to `/home/boxp/.pi/agent/models.json` in the `workspace` container.
+- Set `PI_CODING_AGENT_DIR=/home/boxp/.pi/agent` so non-login `pi` executions use the GitOps-managed config.
 - Allow egress from `codex-workspace` to `local-llm` pods on TCP 8080.
 - Keep image digest updates under the existing `argocd-image-updater` flow.
 
@@ -21,3 +22,7 @@ The Phase 6 end state requires the existing `codex-workspace` Pod to use this lo
   - `curl http://llama-server.local-llm.svc.cluster.local:8080/health`
   - `pi --version`
   - `pi` can call `gemma4-26b` and return `OK`
+
+## Follow-up
+
+The image itself is updated by `argocd-image-updater`; do not pin the generated `sha-*` tag manually in `deployment.yaml`.


### PR DESCRIPTION
## Summary
- set PI_CODING_AGENT_DIR for the workspace container so pi uses the GitOps-managed models.json
- document that codex-workspace image tags remain managed by argocd-image-updater

## Validation
- kubectl kustomize argoproj/codex-workspace
- kubectl apply --dry-run=server -k argoproj/codex-workspace
- live smoke with explicit PI_CODING_AGENT_DIR returned OK from gemma4-26b