### PR TITLE
feat(intel-gpu): add metrics exporter

### DIFF
--- a/argoproj/intel-gpu-device-plugin/exporter-daemonset.yaml
+++ b/argoproj/intel-gpu-device-plugin/exporter-daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-exporter
+  labels:
+    app: intel-gpu-exporter
+spec:
+  selector:
+    matchLabels:
+      app: intel-gpu-exporter
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: intel-gpu-exporter
+    spec:
+      hostPID: true
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"
+        lolice.io/gpu-worker: "true"
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      containers:
+        - name: exporter
+          image: ghcr.io/onedr0p/intel-gpu-exporter@sha256:518d4b4be0a4bedd619e33567804d9b07c2e9dabeeec038d8e36129e31f1cc39
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+              gpu.intel.com/monitoring: "1"
+            limits:
+              cpu: 250m
+              memory: 256Mi
+              gpu.intel.com/monitoring: "1"
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: devfs
+              mountPath: /dev/dri
+      volumes:
+        - name: devfs
+          hostPath:
+            path: /dev/dri

--- a/argoproj/intel-gpu-device-plugin/exporter-service.yaml
+++ b/argoproj/intel-gpu-device-plugin/exporter-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: intel-gpu-exporter
+  labels:
+    app: intel-gpu-exporter
+spec:
+  selector:
+    app: intel-gpu-exporter
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+      protocol: TCP

--- a/argoproj/intel-gpu-device-plugin/exporter-servicemonitor.yaml
+++ b/argoproj/intel-gpu-device-plugin/exporter-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: intel-gpu-exporter
+  labels:
+    app: intel-gpu-exporter
+spec:
+  selector:
+    matchLabels:
+      app: intel-gpu-exporter
+  namespaceSelector:
+    matchNames:
+      - intel-device-plugins
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics

--- a/argoproj/intel-gpu-device-plugin/kustomization.yaml
+++ b/argoproj/intel-gpu-device-plugin/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
   - namespace.yaml
   - node-feature-rules.yaml
   - daemonset.yaml
+  - exporter-daemonset.yaml
+  - exporter-service.yaml
+  - exporter-servicemonitor.yaml

--- a/argoproj/prometheus-operator/prometheus-servicemonitor-role.yaml
+++ b/argoproj/prometheus-operator/prometheus-servicemonitor-role.yaml
@@ -11,3 +11,8 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]

--- a/docs/project_docs/BOXP-23-intel-gpu-metrics-exporter/plan.md
+++ b/docs/project_docs/BOXP-23-intel-gpu-metrics-exporter/plan.md
@@ -1,0 +1,28 @@
+# BOXP-23 Intel GPU metrics exporter
+
+## Background
+
+`golyat-4` exposes `gpu.intel.com/i915=1` and `gpu.intel.com/monitoring=1` through the Intel GPU device plugin. Phase 7 requires GPU usage observability before dashboards and alerts can be finalized.
+
+## Plan
+
+- Keep the exporter in the existing `intel-gpu-device-plugin` Argo CD Application.
+- Use `gpu.intel.com/monitoring: 1` so the exporter receives monitoring access from the device plugin.
+- Schedule only on `lolice.io/gpu-worker=true` / `intel.feature.node.kubernetes.io/gpu=true` nodes and tolerate the GPU worker taint.
+- Expose `/metrics` through a Service and ServiceMonitor in `intel-device-plugins`.
+- Pin the tested exporter image by digest instead of using the upstream `rolling` tag.
+- Extend the existing Prometheus ServiceMonitor RBAC to include `discovery.k8s.io/endpointslices`, because Prometheus is configured with `serviceDiscoveryRole: EndpointSlice`.
+
+## Validation
+
+- `kubectl kustomize argoproj/intel-gpu-device-plugin`
+- `kubectl apply --dry-run=server -k argoproj/intel-gpu-device-plugin`
+- Argo CD `intel-gpu-device-plugin` reaches `Synced Healthy`
+- `intel-gpu-exporter` DaemonSet is `1/1` on `golyat-4`
+- `/metrics` returns `igpu_*` metrics such as `igpu_engines_render_3d_0_busy`, `igpu_power_gpu`, and `igpu_rc6`
+- Prometheus target for `intel-gpu-exporter` is `up`
+- Prometheus query `igpu_rc6` returns a sample for the exporter target
+
+## Notes
+
+An XPU Manager smoke test failed on `golyat-4` with `zeInit error: 78000001`, so the first production metrics path uses an `intel_gpu_top` based exporter. Revisit XPU Manager later if Intel Arc 140T support improves.


### PR DESCRIPTION
## Summary
- add an Intel GPU metrics exporter DaemonSet, Service, and ServiceMonitor for gpu workers
- pin the tested exporter image by digest and request gpu.intel.com/monitoring
- allow Prometheus ServiceMonitor discovery to list EndpointSlices

## Validation
- kubectl kustomize argoproj/intel-gpu-device-plugin
- kubectl apply --dry-run=server -k argoproj/intel-gpu-device-plugin
- kubectl apply --dry-run=server -f argoproj/prometheus-operator/prometheus-servicemonitor-role.yaml
- live smoke: intel-gpu-exporter runs on golyat-4 and /metrics returns igpu_* metrics
- live smoke: Prometheus target serviceMonitor/intel-device-plugins/intel-gpu-exporter/0 is up
- live smoke: Prometheus query igpu_rc6 returns sample for 192.178.122.208:8080

## Notes
- XPU Manager smoke failed on golyat-4 with zeInit error 78000001, so this uses an intel_gpu_top based exporter first.
- Full prometheus-operator server dry-run is blocked by existing kube-prometheus CRD last-applied annotation size, so the changed ClusterRole was validated directly.