### PR TITLE
feat(local-llm): add envoy metrics sidecar

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - --host
             - 0.0.0.0
             - --port
-            - "8080"
+            - "8081"
             - -dev
             - SYCL0
             - --models-preset
@@ -62,8 +62,8 @@ spec:
             - --cpu-moe
             - --no-warmup
           ports:
-            - name: http
-              containerPort: 8080
+            - name: llama-http
+              containerPort: 8081
           env:
             - name: ONEAPI_DEVICE_SELECTOR
               value: level_zero:0
@@ -91,20 +91,20 @@ spec:
           startupProbe:
             httpGet:
               path: /health
-              port: http
+              port: llama-http
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 60
           readinessProbe:
             httpGet:
               path: /health
-              port: http
+              port: llama-http
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
-              port: http
+              port: llama-http
             initialDelaySeconds: 60
             periodSeconds: 20
             timeoutSeconds: 5
@@ -118,6 +118,52 @@ spec:
               mountPath: /config/models.ini
               subPath: models.ini
               readOnly: true
+        - name: envoy
+          image: docker.io/envoyproxy/envoy@sha256:4d496918618a7ebd6c71ae8285e31ebff092f3a0a5ad642d50decf4a54eb2456
+          imagePullPolicy: IfNotPresent
+          args:
+            - -c
+            - /etc/envoy/envoy.yaml
+            - --log-level
+            - warn
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9901
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /server_info
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy/envoy.yaml
+              subPath: envoy.yaml
+              readOnly: true
       volumes:
         - name: models
           hostPath:
@@ -128,3 +174,6 @@ spec:
         - name: models-config
           configMap:
             name: llama-server-models
+        - name: envoy-config
+          configMap:
+            name: llama-server-envoy

--- a/argoproj/local-llm/envoy-config.yaml
+++ b/argoproj/local-llm/envoy-config.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llama-server-envoy
+data:
+  envoy.yaml: |
+    static_resources:
+      listeners:
+        - name: local_llm_http
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 8080
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: local_llm
+                    access_log:
+                      - name: envoy.access_loggers.stdout
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                    route_config:
+                      name: local_llm_route
+                      virtual_hosts:
+                        - name: local_llm
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: llama_server
+                                timeout: 0s
+                                max_stream_duration:
+                                  max_stream_duration: 0s
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      clusters:
+        - name: llama_server
+          connect_timeout: 5s
+          type: STATIC
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: llama_server
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8081
+    admin:
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9901

--- a/argoproj/local-llm/kustomization.yaml
+++ b/argoproj/local-llm/kustomization.yaml
@@ -5,5 +5,7 @@ namespace: local-llm
 resources:
   - namespace.yaml
   - models-config.yaml
+  - envoy-config.yaml
   - deployment.yaml
   - service.yaml
+  - servicemonitor.yaml

--- a/argoproj/local-llm/service.yaml
+++ b/argoproj/local-llm/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: llama-server
+  labels:
+    app: llama-server
 spec:
   type: ClusterIP
   selector:
@@ -10,3 +12,6 @@ spec:
     - name: http
       port: 8080
       targetPort: http
+    - name: metrics
+      port: 9901
+      targetPort: metrics

--- a/argoproj/local-llm/servicemonitor.yaml
+++ b/argoproj/local-llm/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: llama-server-envoy
+  labels:
+    app: llama-server
+spec:
+  selector:
+    matchLabels:
+      app: llama-server
+  namespaceSelector:
+    matchNames:
+      - local-llm
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /stats/prometheus

--- a/docs/project_docs/BOXP-23-local-llm-envoy-metrics/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-envoy-metrics/plan.md
@@ -1,0 +1,24 @@
+# BOXP-23 local-llm Envoy metrics
+
+## Background
+
+The current TurboQuant `llama-server` build does not expose native Prometheus metrics on `/metrics`. Phase 7 still needs request, error, and latency observability for `local-llm`.
+
+## Plan
+
+- Keep the Kubernetes Service endpoint as `llama-server.local-llm.svc.cluster.local:8080`.
+- Move `llama-server` inside the Pod to `0.0.0.0:8081`. The port is only exposed as a container port for kubelet probes and is not published by the Service.
+- Add an Envoy sidecar listening on `0.0.0.0:8080` and proxying to `127.0.0.1:8081`.
+- Expose Envoy admin `/stats/prometheus` on port `9901` through the same Service.
+- Add a ServiceMonitor for Envoy stats.
+- Pin the Envoy image by digest.
+
+## Validation
+
+- `kubectl kustomize argoproj/local-llm`
+- `kubectl apply --dry-run=server -k argoproj/local-llm`
+- `local-llm` Argo CD Application reaches `Synced Healthy`
+- `/health`, `/v1/models`, and `/v1/chat/completions` still work through Service port `8080`
+- `/stats/prometheus` returns Envoy metrics
+- Prometheus target for `llama-server-envoy` is `up`
+- Prometheus query returns `envoy_cluster_upstream_rq_time` and request/error counters for `llama_server`


### PR DESCRIPTION
## Summary
- add an Envoy sidecar in front of local-llm to expose request/error/latency metrics
- keep the public Service endpoint on port 8080 while moving llama-server to 8081 inside the Pod
- expose Envoy /stats/prometheus via ServiceMonitor

## Validation
- kubectl kustomize argoproj/local-llm
- kubectl apply --dry-run=server -k argoproj/local-llm
- live smoke with Argo reconcile paused: Pod reached 2/2 Running
- live smoke: /health, /v1/models, /v1/chat/completions still work through Service port 8080
- live smoke: Envoy /stats/prometheus exposes upstream request counters and latency metrics
- live smoke: Prometheus target serviceMonitor/local-llm/llama-server-envoy/0 is up
- live smoke: Prometheus queries envoy_cluster_upstream_rq_total and envoy_cluster_upstream_rq_time_sum return samples

## Notes
- local-llm currently has argocd.argoproj.io/skip-reconcile=true for live smoke. Remove it after this PR is merged so GitOps owns the tested state.