### PR TITLE
Add local LLM GPU observability

### DIFF
--- a/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
+++ b/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
@@ -1,0 +1,593 @@
+{
+  "editable": false,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "up{job=\"llama-server\", namespace=\"local-llm\", service=\"llama-server\"}",
+          "legendFormat": "local-llm",
+          "refId": "A"
+        }
+      ],
+      "title": "Local LLM Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "up{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\", service=\"intel-gpu-exporter\"}",
+          "legendFormat": "intel-gpu-exporter",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Exporter Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{job=\"llama-server\", namespace=\"local-llm\", envoy_cluster_name=\"llama_server\"}[5m]))",
+          "legendFormat": "requests",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(envoy_cluster_upstream_rq_time_bucket{job=\"llama-server\", namespace=\"local-llm\", envoy_cluster_name=\"llama_server\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Latency p95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_engines_render_3d_0_busy{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "render/3d busy",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_engines_blitter_0_busy{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "blitter busy",
+          "refId": "B"
+        }
+      ],
+      "title": "Intel GPU Engine Busy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "watt"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_power_gpu{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "gpu",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_power_package{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "package",
+          "refId": "B"
+        }
+      ],
+      "title": "Intel GPU Power",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_rc6{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "rc6",
+          "refId": "A"
+        }
+      ],
+      "title": "Intel GPU RC6",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "Bps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_imc_bandwidth_reads{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "reads",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "igpu_imc_bandwidth_writes{job=\"intel-gpu-exporter\", namespace=\"intel-device-plugins\"}",
+          "legendFormat": "writes",
+          "refId": "B"
+        }
+      ],
+      "title": "Intel GPU Memory Bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{job=\"llama-server\", namespace=\"local-llm\", envoy_cluster_name=\"llama_server\"}[5m]))",
+          "legendFormat": "requests",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{job=\"llama-server\", namespace=\"local-llm\", envoy_cluster_name=\"llama_server\", envoy_response_code_class=\"5\"}[5m]))",
+          "legendFormat": "5xx",
+          "refId": "B"
+        }
+      ],
+      "title": "Local LLM Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(envoy_cluster_upstream_rq_time_bucket{job=\"llama-server\", namespace=\"local-llm\", envoy_cluster_name=\"llama_server\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{job=\"llama-server\", namespace=\"local-llm\", envoy_cluster_name=\"llama_server\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Local LLM Request Latency",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "local-llm",
+    "gpu"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "query": "prometheus",
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "UTC",
+  "title": "Local LLM / GPU Overview",
+  "uid": "local-llm-gpu-overview",
+  "version": 1
+}

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - grafana-pvc.yaml
 - scrape-config.yaml
 - control-plane-node-rules.yaml
+- local-llm-gpu-observability-rules.yaml
 - cloudflared-pod-monitor.yaml
 - etcd-service.yaml
 - etcd-servicemonitor.yaml
@@ -34,3 +35,15 @@ patchesJson6902:
       name: grafana
       namespace: monitoring
   path: patches/grafana-remove-empty-dir.yaml
+configMapGenerator:
+- name: grafana-dashboard-local-llm-gpu-overview
+  namespace: monitoring
+  files:
+  - local-llm-gpu-overview.json=dashboards/local-llm-gpu-overview.json
+  options:
+    disableNameSuffixHash: true
+    labels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: 13.0.2

--- a/argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml
+++ b/argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml
@@ -1,0 +1,48 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: local-llm-gpu-observability-rules
+  namespace: monitoring
+  labels:
+    prometheus: k8s
+    role: alert-rules
+    release: prometheus
+spec:
+  groups:
+    - name: local-llm-gpu-observability.rules
+      rules:
+        - alert: LocalLlmTargetDown
+          expr: |
+            absent(up{job="llama-server", namespace="local-llm", service="llama-server"})
+            or
+            up{job="llama-server", namespace="local-llm", service="llama-server"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Local LLM metrics target is down
+            description: Prometheus cannot scrape the local-llm Envoy metrics target for more than 5 minutes.
+        - alert: LocalLlmHigh5xxRate
+          expr: |
+            (
+              sum(rate(envoy_cluster_upstream_rq_xx{job="llama-server", namespace="local-llm", envoy_cluster_name="llama_server", envoy_response_code_class="5"}[5m]))
+              /
+              clamp_min(sum(rate(envoy_cluster_upstream_rq_total{job="llama-server", namespace="local-llm", envoy_cluster_name="llama_server"}[5m])), 0.001)
+            ) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Local LLM has a high 5xx response rate
+            description: More than 5 percent of local-llm upstream requests have returned 5xx responses for 10 minutes.
+        - alert: IntelGpuExporterDown
+          expr: |
+            absent(up{job="intel-gpu-exporter", namespace="intel-device-plugins", service="intel-gpu-exporter"})
+            or
+            up{job="intel-gpu-exporter", namespace="intel-device-plugins", service="intel-gpu-exporter"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Intel GPU exporter is down
+            description: Prometheus cannot scrape the Intel GPU exporter target for more than 5 minutes.

--- a/argoproj/prometheus-operator/overlays/grafana.yaml
+++ b/argoproj/prometheus-operator/overlays/grafana.yaml
@@ -15,7 +15,13 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - mountPath: /grafana-dashboard-definitions/0/local-llm-gpu-overview
+              name: grafana-dashboard-local-llm-gpu-overview
       volumes:
         - name: grafana-storage
           persistentVolumeClaim:
             claimName: grafana-pvc
+        - name: grafana-dashboard-local-llm-gpu-overview
+          configMap:
+            name: grafana-dashboard-local-llm-gpu-overview

--- a/docs/project_docs/BOXP-23-local-llm-gpu-observability/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-gpu-observability/plan.md
@@ -1,0 +1,36 @@
+# B0XP-23 local LLM / GPU observability
+
+## Goal
+
+Add first-class observability for the GPU-backed local LLM workload using the repository's existing kube-prometheus GitOps pattern.
+
+## Scope
+
+- Add a Grafana dashboard for `local-llm` request/error/latency metrics and Intel GPU exporter metrics.
+- Add Prometheus alerts for local LLM target health, local LLM 5xx ratio, and Intel GPU exporter health.
+- Do not hand-edit image digests. `ghcr.io/boxp/arch/llama-sycl` stays managed by `argocd-image-updater`.
+
+## Files
+
+- `argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml`
+- `argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`
+- `argoproj/prometheus-operator/kustomization.yaml`
+- `argoproj/prometheus-operator/overlays/grafana.yaml`
+
+## Validation
+
+- `jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`
+- `kubectl kustomize argoproj/prometheus-operator`
+- `kubectl apply --dry-run=server -f argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml`
+- Prometheus API query checks for:
+  - `up{job="llama-server", namespace="local-llm", service="llama-server"}`
+  - `up{job="intel-gpu-exporter", namespace="intel-device-plugins", service="intel-gpu-exporter"}`
+  - `envoy_cluster_upstream_rq_total`
+  - `envoy_cluster_upstream_rq_time_bucket`
+
+## Rollout
+
+1. Merge the PR to `main`.
+2. Let Argo CD sync `prometheus-operator`.
+3. Verify `local-llm-gpu-observability-rules` exists in Prometheus.
+4. Verify Grafana loads `Local LLM / GPU Overview`.


### PR DESCRIPTION
## Summary
- add PrometheusRule alerts for local-llm Envoy metrics and Intel GPU exporter scrape health
- add a Grafana dashboard for local-llm request/error/latency and Intel GPU metrics
- document the rollout plan and keep local-llm image updates under argocd-image-updater management

## Validation
- jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
- kubectl kustomize argoproj/prometheus-operator
- kubectl apply --dry-run=server -f argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml
- Prometheus API query checks for local-llm Envoy and intel-gpu-exporter metrics