### PR TITLE
Add GPU worker package temperature observability

### DIFF
--- a/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
+++ b/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
@@ -453,6 +453,81 @@
             "fillOpacity": 10,
             "showPoints": "never"
           },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "celsius"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "node_thermal_zone_temp{job=\"node-exporter\", instance=\"golyat-4\", type=\"x86_pkg_temp\"}",
+          "legendFormat": "golyat-4 package",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "node_thermal_zone_temp{job=\"node-exporter\", instance=\"golyat-4\", type=\"acpitz\", zone=\"1\"}",
+          "legendFormat": "golyat-4 ACPI",
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Worker Package Temperature",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
           "unit": "reqps"
         }
       },
@@ -460,7 +535,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "id": 9,
       "options": {
@@ -518,7 +593,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 29
       },
       "id": 10,
       "options": {

--- a/argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml
+++ b/argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml
@@ -46,3 +46,12 @@ spec:
           annotations:
             summary: Intel GPU exporter is down
             description: Prometheus cannot scrape the Intel GPU exporter target for more than 5 minutes.
+        - alert: GpuWorkerPackageTemperatureHigh
+          expr: |
+            node_thermal_zone_temp{job="node-exporter", instance="golyat-4", type="x86_pkg_temp"} > 90
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: GPU worker package temperature is high
+            description: golyat-4 package temperature has been above 90C for more than 10 minutes. Arc 140T is an iGPU, so this is the closest available package-level thermal signal rather than a discrete GPU sensor.

--- a/docs/project_docs/BOXP-23-gpu-worker-temperature-dashboard/plan.md
+++ b/docs/project_docs/BOXP-23-gpu-worker-temperature-dashboard/plan.md
@@ -1,0 +1,29 @@
+# B0XP-23 GPU worker temperature observability
+
+## Goal
+
+Add the available thermal signal for the GPU worker to the local LLM / GPU observability dashboard and alerts.
+
+## Context
+
+`golyat-4` uses Intel Arc 140T iGPU. The current `intel_gpu_top` exporter provides engine busy, frequency, memory bandwidth, power, and RC6, but not a discrete GPU temperature or VRAM metric.
+
+Current host evidence:
+
+- no GPU-specific DRM hwmon directory under `/sys/class/drm/card0/device/hwmon`
+- `intel_gpu_top -J` does not expose temperature or VRAM
+- `node_thermal_zone_temp{instance="golyat-4", type="x86_pkg_temp"}` is available in Prometheus
+- `clinfo` reports OpenCL global memory as shared system memory, not discrete VRAM
+
+## Change
+
+- Add `GPU Worker Package Temperature` panel to `Local LLM / GPU Overview`.
+- Add `GpuWorkerPackageTemperatureHigh` alert using `golyat-4` `x86_pkg_temp`.
+
+## Validation
+
+- `jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`
+- `kubectl kustomize argoproj/prometheus-operator`
+- `kubectl --server=https://192.168.10.102:6443 apply --dry-run=server -f argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml`
+- Prometheus API query:
+  - `node_thermal_zone_temp{job="node-exporter", instance="golyat-4", type="x86_pkg_temp"}`


### PR DESCRIPTION
## Summary
- add golyat-4 package temperature to the Local LLM / GPU Overview dashboard
- add a warning alert for high GPU worker package temperature
- document why this uses x86 package temperature instead of a discrete GPU sensor on Arc 140T iGPU

## Validation
- jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
- kubectl kustomize argoproj/prometheus-operator
- kubectl --server=https://192.168.10.102:6443 apply --dry-run=server -f argoproj/prometheus-operator/local-llm-gpu-observability-rules.yaml
- Prometheus query for node_thermal_zone_temp{instance="golyat-4", type="x86_pkg_temp"}