### PR TITLE
Add official Ornith model to local-llm router

### DIFF
--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -9,3 +9,10 @@ data:
     [gemma4-26b]
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
     load-on-startup = true
+
+    [ornith-35b]
+    model = /models/ornith-1.0-35b-Q4_K_M.gguf
+    ctx-size = 65536
+    batch-size = 128
+    ubatch-size = 32
+    reasoning-budget = 0

--- a/docs/project_docs/BOXP-23-local-llm-official-ornith/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-official-ornith/plan.md
@@ -1,0 +1,29 @@
+# BOXP-23 local-llm official Ornith
+
+## Context
+
+Phase 6 needs the `local-llm` router to expose both `gemma4-26b` and `ornith-35b` with `--models-max 1`.
+
+The initially seeded `zaakirio/Ornith-1.0-35B-uncensored-GGUF` Q4_K_M file loaded but produced malformed output on both Ooedo and lolice. The official `deepreinforce-ai/Ornith-1.0-35B-GGUF` Q4_K_M file was then seeded to `golyat-4:/var/lib/local-llm/models/ornith-1.0-35b-Q4_K_M.gguf` and passed standalone and router smoke tests.
+
+## Plan
+
+- Add `ornith-35b` to `argoproj/local-llm/models-config.yaml`.
+- Keep `gemma4-26b` as the startup-loaded model.
+- Point `ornith-35b` at the official GGUF file: `/models/ornith-1.0-35b-Q4_K_M.gguf`.
+- Include Ornith-specific conservative settings from the verified smoke: `ctx-size 65536`, `batch-size 128`, `ubatch-size 32`, `reasoning-budget 0`.
+- Do not edit the `local-llm` workload image tag or digest. Image state is managed by `argocd-image-updater`.
+
+## Verification
+
+- `kubectl kustomize argoproj/local-llm`
+- Temporary in-pod router smoke on `golyat-4`:
+  - initial `gemma4-26b` loaded and returned `OK`
+  - `POST /models/load {"model":"ornith-35b"}` unloaded Gemma4 and loaded Ornith
+  - `ornith-35b` returned `OK`
+  - `POST /models/load {"model":"gemma4-26b"}` unloaded Ornith and reloaded Gemma4
+  - `gemma4-26b` returned `OK`
+- After merge/sync:
+  - Argo CD `local-llm` reaches `Synced Healthy`
+  - `/v1/models` shows `gemma4-26b` and `ornith-35b`
+  - `gemma4-26b` and `ornith-35b` each pass a short `Return exactly: OK` completion through the Service


### PR DESCRIPTION
## Summary

- add `ornith-35b` to the `local-llm` router ConfigMap
- point Ornith at the official `deepreinforce-ai/Ornith-1.0-35B-GGUF` Q4_K_M file on `golyat-4` local model storage
- keep `gemma4-26b` as the startup-loaded model and keep `--models-max 1` switching behavior

## Validation

- `kubectl kustomize argoproj/local-llm`
- `kubectl --server=https://192.168.10.102:6443 apply --dry-run=server -k argoproj/local-llm`
- temporary in-pod router smoke on `golyat-4`:
  - initial `gemma4-26b` loaded and returned `OK`
  - `POST /models/load {"model":"ornith-35b"}` unloaded Gemma4 and loaded Ornith
  - `ornith-35b` returned `OK`
  - `POST /models/load {"model":"gemma4-26b"}` unloaded Ornith and reloaded Gemma4
  - final `gemma4-26b` returned `OK`

## Notes

The earlier `zaakirio/Ornith-1.0-35B-uncensored-GGUF` artifact was rejected because it produced malformed output on both Ooedo and lolice. The official file is seeded at:

- path: `/var/lib/local-llm/models/ornith-1.0-35b-Q4_K_M.gguf`
- size: `21166757760` bytes
- sha256: `ff25291b2599fb927a835e624d2b3540106af61761c3fa57ac4264046dbec002`

This PR does not change image tags or digests. `local-llm` image state remains managed by `argocd-image-updater`.
