### PR TITLE
Fix pi agent config mount in codex workspace

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -27,9 +27,12 @@ spec:
             - |
               mkdir -p /home/boxp/.ssh
               mkdir -p /home/boxp/.pi/agent
+              rm -f /home/boxp/.pi/agent/models.json
+              ln -s /etc/pi-agent-config/models.json /home/boxp/.pi/agent/models.json
               curl -fsSL https://github.com/boxp.keys -o /home/boxp/.ssh/authorized_keys
               test -s /home/boxp/.ssh/authorized_keys
               chown -R 1000:1000 /home/boxp/.ssh
+              chown -h 1000:1000 /home/boxp/.pi/agent/models.json
               chmod 700 /home/boxp/.ssh
               chmod 600 /home/boxp/.ssh/authorized_keys
           securityContext:
@@ -159,8 +162,7 @@ spec:
             - name: home
               mountPath: /home/boxp
             - name: pi-config
-              mountPath: /home/boxp/.pi/agent/models.json
-              subPath: models.json
+              mountPath: /etc/pi-agent-config
               readOnly: true
             - name: sshd-config
               mountPath: /etc/ssh/sshd_config

--- a/docs/project_docs/BOXP-23-codex-workspace-pi-config-live/plan.md
+++ b/docs/project_docs/BOXP-23-codex-workspace-pi-config-live/plan.md
@@ -1,0 +1,20 @@
+# BOXP-23 codex-workspace pi config live update
+
+## Goal
+
+Make `codex-workspace` consume the updated pi agent `models.json` ConfigMap without pinning an old file through a Kubernetes `subPath` bind mount.
+
+## Context
+
+`local-llm` already runs `gemma4-26b` and `ornith-35b` with `ctx-size = 65536`, `--models-max 1`, Turbo3 KV cache, and the Ooedo/Lunar batch settings. The live `codex-workspace` Pod still saw the old pi config because `/home/boxp/.pi/agent/models.json` was mounted as a single ConfigMap key via `subPath`. Kubernetes does not live-update existing subPath file mounts, so the ConfigMap volume had the new file while the container still read the old bind-mounted copy.
+
+## Plan
+
+1. Mount the `pi-config` ConfigMap as a directory at `/etc/pi-agent-config` instead of directly over `/home/boxp/.pi/agent/models.json`.
+2. During the existing `fetch-ssh-keys` initContainer, replace `/home/boxp/.pi/agent/models.json` with a symlink to `/etc/pi-agent-config/models.json`.
+3. Keep the rest of `/home/boxp/.pi/agent` on the persistent home volume so `auth.json`, sessions, settings, hooks, skills, and extensions are not hidden by a ConfigMap directory mount.
+
+## Validation
+
+- `kubectl kustomize argoproj/codex-workspace`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- stop mounting pi agent models.json through a ConfigMap subPath
- mount the pi config ConfigMap as /etc/pi-agent-config and symlink models.json from the persistent pi agent directory
- keep auth.json, sessions, settings, hooks, skills, and extensions on the home volume

## Validation
- kubectl kustomize argoproj/codex-workspace
- git diff --check

## Notes
- live local-llm already has Gemma4 and Ornith with n_ctx=65536 and model switching smoke passed directly against the Pod IP
- Kubernetes API is currently blocked by control-plane etcd no-leader state, so server-side dry-run and live codex-workspace rollout validation are deferred until control-plane recovery