### PR TITLE
Enable on-demand local LLM model loading

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -43,7 +43,6 @@ spec:
             - /config/models.ini
             - --models-max
             - "1"
-            - --no-models-autoload
             - -ngl
             - "3"
             - -c

--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -11,7 +11,6 @@ data:
     ctx-size = 65536
     batch-size = 256
     ubatch-size = 64
-    load-on-startup = true
 
     [ornith-35b]
     model = /models/ornith-1.0-35b-Q4_K_M.gguf

--- a/docs/project_docs/BOXP-23-local-llm-autoload/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-autoload/plan.md
@@ -1,0 +1,29 @@
+# BOXP-23 local-llm autoload
+
+## Goal
+
+Start the local LLM router with all production models unloaded, then load the requested model on demand from the request body.
+
+## Context
+
+The previous production router used `--models-max 1`, `--no-models-autoload`, and `load-on-startup = true` for `gemma4-26b`. That made Gemma4 load at startup and made `ornith-35b` return `400 model is not loaded` unless `/models/load` was called manually.
+
+The desired behavior is:
+
+- `llama-server` starts with `gemma4-26b` and `ornith-35b` both unloaded.
+- A request with `model: gemma4-26b` loads Gemma4 on demand.
+- A request with `model: ornith-35b` loads Ornith on demand.
+- `--models-max 1` remains in place so only one model is resident at a time.
+
+## Changes
+
+- Remove `--no-models-autoload` from the `local-llm` Deployment.
+- Remove `load-on-startup = true` from the Gemma4 router preset.
+- Keep Ooedo/Lunar runtime sizing and Intel SYCL settings unchanged.
+
+## Validation
+
+- `kubectl kustomize argoproj/local-llm`
+- `git diff --check`
+- Server-side dry-run against the live cluster.
+- After merge: verify `/v1/models` starts with both production models unloaded, then pi/API requests autoload Gemma4 and Ornith successfully.


### PR DESCRIPTION
## Summary
- start local-llm with production models unloaded
- remove router no-autoload mode so requests can load the requested model
- keep --models-max 1, Turbo3, flash attention, ngl 3, and Ooedo/Lunar batch sizing

## Validation
- kubectl kustomize argoproj/local-llm
- git diff --check
- kubectl kustomize argoproj/local-llm | kubectl apply --dry-run=server -f - via shanghai-2 API