### PR TITLE
Add local LLM token throughput dashboard panel

### DIFF
--- a/.github/workflows/argocd-diff.yaml
+++ b/.github/workflows/argocd-diff.yaml
@@ -33,9 +33,11 @@ jobs:
           rm argocd-linux-amd64
 
           # kustomizeのインストール
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          KUSTOMIZE_VERSION=v5.7.1
+          curl -sSL -o kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          tar -xzf kustomize.tar.gz kustomize
           sudo install -m 555 kustomize /usr/local/bin/kustomize
-          rm kustomize
+          rm kustomize kustomize.tar.gz
 
           # Helmのインストール
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3

--- a/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
+++ b/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
@@ -632,6 +632,77 @@
       ],
       "title": "Local LLM Request Latency",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokiDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "showPoints": "auto"
+          },
+          "decimals": 2,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokiDatasource}"
+          },
+          "expr": "avg_over_time({namespace=\"local-llm\",container=\"llama-server\"} |= \"prompt eval time\" | regexp \"(?P<tps>[0-9]+(?:\\.[0-9]+)?) tokens per second\" | unwrap tps | __error__=\"\" [$__interval])",
+          "legendFormat": "prompt eval",
+          "queryType": "range",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokiDatasource}"
+          },
+          "expr": "avg_over_time({namespace=\"local-llm\",container=\"llama-server\"} |= \"eval time =\" != \"prompt eval time\" | regexp \"(?P<tps>[0-9]+(?:\\.[0-9]+)?) tokens per second\" | unwrap tps | __error__=\"\" [$__interval])",
+          "legendFormat": "generation",
+          "queryType": "range",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokiDatasource}"
+          },
+          "expr": "avg_over_time({namespace=\"local-llm\",container=\"llama-server\"} |= \"prompt processing\" | regexp \"(?P<tps>[0-9]+(?:\\.[0-9]+)?) tokens per second\" | unwrap tps | __error__=\"\" [$__interval])",
+          "legendFormat": "prompt processing",
+          "queryType": "range",
+          "refId": "C"
+        }
+      ],
+      "title": "Local LLM Token Throughput",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -652,6 +723,19 @@
         "label": "Data source",
         "name": "datasource",
         "query": "prometheus",
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "Loki",
+          "value": "Loki"
+        },
+        "hide": 0,
+        "label": "Loki data source",
+        "name": "lokiDatasource",
+        "query": "loki",
         "regex": "",
         "type": "datasource"
       }

--- a/docs/project_docs/BOXP-23-local-llm-token-rate-dashboard/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-token-rate-dashboard/plan.md
@@ -1,0 +1,33 @@
+# BOXP-23 local LLM token rate dashboard
+
+## Goal
+
+Show local LLM token throughput on the existing `Local LLM / GPU Overview` dashboard.
+
+## Background
+
+The current `llama-server` / Envoy / Prometheus path does not expose native token throughput metrics. The available token/s signal is emitted in `llama-server` logs, for example `tokens per second` timing lines. Loki is configured as a Grafana datasource, so the first implementation should add LogQL panels that extract token throughput from `local-llm` logs.
+
+## Scope
+
+- Add token/s panels to `argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`.
+- Use the existing Loki datasource by name for LogQL panels.
+- Keep existing Prometheus request, latency, GPU, and temperature panels unchanged.
+- Fix the `argocd-diff` workflow kustomize install step if the PR check fails before manifest validation.
+- Do not edit `local-llm` workload image tags or digests.
+
+## Validation
+
+- `jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`
+- `kubectl kustomize argoproj/prometheus-operator`
+- YAML parse of `.github/workflows/argocd-diff.yaml`
+- Local `/tmp` smoke of the pinned kustomize v5.7.1 download/extract path used by `argocd-diff`
+- Live Loki query check for `local-llm` `llama-server` `tokens per second` log lines.
+- Confirm whether the current `llama-server` Pod stream is present in Loki; if not, track Alloy/Loki ingestion separately.
+
+## Rollout
+
+1. Merge the PR to `main`.
+2. Let Argo CD sync `prometheus-operator`.
+3. Verify Grafana reloads `Local LLM / GPU Overview`.
+4. Generate a short `local-llm` request and confirm token/s panels update from Loki.


### PR DESCRIPTION
## Summary
- add a Loki datasource variable to the Local LLM / GPU Overview dashboard
- add a LogQL-based Local LLM Token Throughput panel for prompt eval, generation, and prompt processing token/s
- pin the `argocd-diff` workflow kustomize install to the v5.7.1 release tarball so the check reaches manifest validation
- add the project plan under docs/project_docs/BOXP-23-local-llm-token-rate-dashboard/plan.md

## Validation
- `git diff --check`
- `jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`
- `kubectl kustomize argoproj/prometheus-operator`
- YAML parse of `.github/workflows/argocd-diff.yaml`
- local `/tmp` smoke of the pinned kustomize v5.7.1 download/extract path
- server dry-run of `grafana-dashboard-local-llm-gpu-overview` ConfigMap
- live Loki LogQL syntax checks through the Grafana Pod
- live LogQL prompt-processing query returned `0.06` token/s from the existing Loki stream

## Notes
- `llama-server` / Envoy / Prometheus do not currently expose native token/s metrics, so this uses Loki log extraction.
- Current live Loki still returns the older `llama-server-6bd4cbd644-zsk68` stream, while the current `llama-server-5565df8ff-f8wtg` stream has not appeared yet. Alloy/Loki ingestion for the current Pod is tracked separately in the project TODO.
- This PR does not edit local-llm image state; `argocd-image-updater` remains the image owner.