### PR TITLE
Support local LLM slot timing throughput

### DIFF
--- a/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
+++ b/argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json
@@ -699,6 +699,16 @@
           "legendFormat": "prompt processing",
           "queryType": "range",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokiDatasource}"
+          },
+          "expr": "avg_over_time({namespace=\"local-llm\",container=\"llama-server\"} |= \"tg =\" | regexp \"(?P<tps>[0-9.]+) t/s\" | unwrap tps | __error__=\"\" [$__interval])",
+          "legendFormat": "generation slot timing",
+          "queryType": "range",
+          "refId": "D"
         }
       ],
       "title": "Local LLM Token Throughput",

--- a/docs/project_docs/BOXP-23-local-llm-token-rate-dashboard/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-token-rate-dashboard/plan.md
@@ -6,12 +6,13 @@ Show local LLM token throughput on the existing `Local LLM / GPU Overview` dashb
 
 ## Background
 
-The current `llama-server` / Envoy / Prometheus path does not expose native token throughput metrics. The available token/s signal is emitted in `llama-server` logs, for example `tokens per second` timing lines. Loki is configured as a Grafana datasource, so the first implementation should add LogQL panels that extract token throughput from `local-llm` logs.
+The current `llama-server` / Envoy / Prometheus path does not expose native token throughput metrics. The available token/s signal is emitted in `llama-server` logs, for example `tokens per second` timing lines and TurboQuant/SYCL slot timing lines such as `tg = ... t/s`. Loki is configured as a Grafana datasource, so the first implementation should add LogQL panels that extract token throughput from `local-llm` logs.
 
 ## Scope
 
 - Add token/s panels to `argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`.
 - Use the existing Loki datasource by name for LogQL panels.
+- Support both classic llama timing logs and the live TurboQuant/SYCL `tg = ... t/s` generation timing format.
 - Keep existing Prometheus request, latency, GPU, and temperature panels unchanged.
 - Fix the `argocd-diff` workflow kustomize install step if the PR check fails before manifest validation.
 - Do not edit `local-llm` workload image tags or digests.
@@ -23,6 +24,7 @@ The current `llama-server` / Envoy / Prometheus path does not expose native toke
 - YAML parse of `.github/workflows/argocd-diff.yaml`
 - Local `/tmp` smoke of the pinned kustomize v5.7.1 download/extract path used by `argocd-diff`
 - Live Loki query check for `local-llm` `llama-server` `tokens per second` log lines.
+- Live Loki query check for `local-llm` `llama-server` `tg = ... t/s` slot timing log lines.
 - Confirm whether the current `llama-server` Pod stream is present in Loki; if not, track Alloy/Loki ingestion separately.
 
 ## Rollout


### PR DESCRIPTION
## Summary
- add a Local LLM token/s dashboard series for TurboQuant/SYCL `tg = ... t/s` slot timing logs
- document that both classic llama timing logs and live slot timing logs are supported

## Validation
- `jq empty argoproj/prometheus-operator/dashboards/local-llm-gpu-overview.json`
- `kubectl kustomize argoproj/prometheus-operator`
- `git diff --check`
- target ConfigMap `apply --dry-run=server` passed
- live Loki query for `tg = ... t/s` returned current pod `llama-server-5565df8ff-f8wtg` at `7.98 t/s`
- `codex review --uncommitted` reported no issues

Note: whole prometheus-operator server dry-run still hits an existing CRD annotation size limit unrelated to this dashboard ConfigMap.