### PR TITLE
Switch local LLM to Vulkan turbo3

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
@@ -7,15 +7,15 @@ spec:
   applicationRefs:
     - namePattern: "local-llm"
       images:
-        - alias: "llama-sycl"
-          imageName: "ghcr.io/boxp/arch/llama-sycl:latest"
+        - alias: "llama-vulkan"
+          imageName: "ghcr.io/boxp/arch/llama-vulkan:latest"
           commonUpdateSettings:
             updateStrategy: "digest"
             platforms:
               - "linux/amd64"
           manifestTargets:
             kustomize:
-              name: "ghcr.io/boxp/arch/llama-sycl"
+              name: "ghcr.io/boxp/arch/llama-vulkan"
   writeBackConfig:
     method: "git:secret:argocd/repo-lolice"
     gitConfig:

--- a/argoproj/local-llm/.argocd-source-local-llm.yaml
+++ b/argoproj/local-llm/.argocd-source-local-llm.yaml
@@ -1,3 +1,3 @@
 kustomize:
   images:
-  - ghcr.io/boxp/arch/llama-sycl=ghcr.io/boxp/arch/llama-sycl:latest@sha256:2284a06057ecfcfe68ac3b35cca4867d509fa711789f9952b0a4c4d97644d3d0
+  - ghcr.io/boxp/arch/llama-vulkan=ghcr.io/boxp/arch/llama-vulkan:latest

--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           - 110
       containers:
         - name: llama-server
-          image: ghcr.io/boxp/arch/llama-sycl:latest
+          image: ghcr.io/boxp/arch/llama-vulkan:latest
           imagePullPolicy: Always
           args:
             - llama-server
@@ -38,7 +38,7 @@ spec:
             - --port
             - "8081"
             - -dev
-            - SYCL0
+            - Vulkan0
             - --models-preset
             - /config/models.ini
             - --models-max
@@ -52,7 +52,7 @@ spec:
             - --cache-type-k
             - q8_0
             - --cache-type-v
-            - f16
+            - turbo3
             - -fa
             - "on"
             - --jinja
@@ -64,8 +64,6 @@ spec:
             - name: llama-http
               containerPort: 8081
           env:
-            - name: ONEAPI_DEVICE_SELECTOR
-              value: level_zero:0
             - name: ZES_ENABLE_SYSMAN
               value: "1"
             - name: HOME
@@ -84,8 +82,6 @@ spec:
               memory: 16Gi
               gpu.intel.com/i915: "1"
             limits:
-              cpu: "12"
-              memory: 80Gi
               gpu.intel.com/i915: "1"
           startupProbe:
             httpGet:

--- a/docs/project_docs/BOXP-23-local-llm-vulkan-turbo3/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-vulkan-turbo3/plan.md
@@ -1,0 +1,24 @@
+# BOXP-23 local-llm Vulkan turbo3 production switch
+
+## Context
+
+`golyat-4` host smoke showed that TheTom `llama-cpp-turboquant` commit `a33ef00b1` with Vulkan can start Gemma4 using `--cache-type-v turbo3` and return readable Japanese. The current production SYCL path has shown unstable behavior around `q8_0` and the cclecle `turbo3` path.
+
+The image itself is still updated by `argocd-image-updater`; this change updates the `local-llm` image name, ImageUpdater target, runtime args, and resource policy in `boxp/lolice`.
+
+## Plan
+
+1. Switch `local-llm` image from `ghcr.io/boxp/arch/llama-sycl:latest` to `ghcr.io/boxp/arch/llama-vulkan:latest`.
+2. Update the `local-llm` ImageUpdater target to track `llama-vulkan` by digest.
+3. Switch runtime device from `-dev SYCL0` to `-dev Vulkan0`.
+4. Restore `--cache-type-v turbo3` for the production model server.
+5. Remove CPU and memory hard limits from the `llama-server` container while keeping requests and the Intel GPU extended resource limit. This avoids cgroup memory pressure competing with the iGPU's shared-memory allocation path.
+6. Keep router mode, `--models-max 1`, `-ngl 99`, `-c 65536`, Flash Attention, Jinja, reasoning off, CPU MoE, and existing model presets.
+7. Let ImageUpdater manage the image digest after the matching `boxp/arch` image PR publishes the TheTom+Vulkan image.
+
+## Validation
+
+- `kubectl kustomize argoproj/local-llm`
+- `kubectl kustomize argoproj/argocd-image-updater`
+- server-side dry-run for `argoproj/local-llm`
+- After image rollout: `/health`, `/v1/models`, Gemma4 Japanese smoke, model switch smoke, and token/s / GPU utilization check.


### PR DESCRIPTION
## Summary
- switch `local-llm` from `ghcr.io/boxp/arch/llama-sycl` to `ghcr.io/boxp/arch/llama-vulkan`
- change runtime device from `SYCL0` to `Vulkan0`
- restore `--cache-type-v turbo3`
- remove CPU/memory hard limits from the `llama-server` container while keeping requests and the Intel GPU extended resource limit
- update the `local-llm` ImageUpdater target to track `llama-vulkan` by digest

## Validation
- `kubectl kustomize argoproj/local-llm`
- `kubectl kustomize argoproj/argocd-image-updater`
- `kubectl --server=https://192.168.10.103:6443 apply --dry-run=server -k argoproj/local-llm`
- `kubectl --server=https://192.168.10.103:6443 apply --dry-run=server -k argoproj/argocd-image-updater`

## Rollout order
Do not merge this until `ghcr.io/boxp/arch/llama-vulkan:latest` exists from the matching arch PR. Merging before that would make the Pod pull a non-existent image.