### PR TITLE
Increase local LLM Vulkan batch sizes

### DIFF
--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -9,12 +9,12 @@ data:
     [gemma4-26b]
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
     ctx-size = 65536
-    batch-size = 256
-    ubatch-size = 64
+    batch-size = 512
+    ubatch-size = 128
 
     [ornith-35b]
     model = /models/ornith-1.0-35b-Q4_K_M.gguf
     ctx-size = 65536
-    batch-size = 128
-    ubatch-size = 32
+    batch-size = 256
+    ubatch-size = 64
     reasoning-budget = 0


### PR DESCRIPTION
## Summary
- increase Gemma4 batch/ubatch to 512/128
- increase Ornith batch/ubatch to 256/64

## Validation
- kubectl kustomize argoproj/local-llm
- kubectl --server=https://192.168.10.103:6443 apply --dry-run=server -k argoproj/local-llm

This is intended for live production throughput validation on the current TheTom Vulkan/turbo3 path.