### PR TITLE
Set local LLM model threads to 8

### DIFF
--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -11,10 +11,14 @@ data:
     ctx-size = 65536
     batch-size = 1024
     ubatch-size = 256
+    threads = 8
+    threads-batch = 8
 
     [ornith-35b]
     model = /models/ornith-1.0-35b-Q4_K_M.gguf
     ctx-size = 65536
     batch-size = 512
     ubatch-size = 128
+    threads = 8
+    threads-batch = 8
     reasoning-budget = 0


### PR DESCRIPTION
## Summary
- set Gemma4 threads/threads-batch to 8/8
- set Ornith threads/threads-batch to 8/8

## Validation
- kubectl kustomize argoproj/local-llm
- kubectl --server=https://192.168.10.103:6443 apply --dry-run=server -k argoproj/local-llm

This is intended to validate whether the CPU-side MoE/prompt path improves on the current Vulkan/turbo3 production settings.