### PR TITLE
Set local LLM model threads to 12

### DIFF
--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -11,14 +11,14 @@ data:
     ctx-size = 65536
     batch-size = 1024
     ubatch-size = 256
-    threads = 8
-    threads-batch = 8
+    threads = 12
+    threads-batch = 12
 
     [ornith-35b]
     model = /models/ornith-1.0-35b-Q4_K_M.gguf
     ctx-size = 65536
     batch-size = 512
     ubatch-size = 128
-    threads = 8
-    threads-batch = 8
+    threads = 12
+    threads-batch = 12
     reasoning-budget = 0


### PR DESCRIPTION
## Summary
- increase Gemma4 threads/threads-batch from 8/8 to 12/12
- increase Ornith threads/threads-batch from 8/8 to 12/12

## Validation
- kubectl kustomize argoproj/local-llm
- kubectl --server=https://192.168.10.103:6443 apply --dry-run=server -k argoproj/local-llm

The GPU worker is effectively dedicated to local-llm, so this tests whether the CPU-side MoE/prompt path benefits from more threads.