### PR TITLE
Run local LLM without CPU MoE

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -58,7 +58,6 @@ spec:
             - --jinja
             - --reasoning
             - "off"
-            - --cpu-moe
             - --no-warmup
           ports:
             - name: llama-http


### PR DESCRIPTION
## Summary
- remove --cpu-moe from local-llm router args
- keep current Vulkan/turbo3, batch/ubatch, and threads settings

## Validation
- kubectl kustomize argoproj/local-llm and confirm cpu-moe is absent
- kubectl --server=https://192.168.10.103:6443 apply --dry-run=server -k argoproj/local-llm

This tests whether iGPU/shared-memory production behaves better when MoE weights are no longer forced to CPU.