### PR TITLE
Adjust local LLM KV cache for cpu MoE

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -52,9 +52,10 @@ spec:
             - --cache-type-k
             - q8_0
             - --cache-type-v
-            - turbo3
+            - q8_0
             - -fa
             - "on"
+            - --cpu-moe
             - --jinja
             - --reasoning
             - "off"


### PR DESCRIPTION
## Summary
- restore `--cpu-moe` for the local LLM deployment
- switch V cache from `turbo3` to `q8_0` for the next stability test

## Test
- `ruby -e 'require "yaml"; YAML.load_file("argoproj/local-llm/deployment.yaml"); puts "yaml ok"'`\n