### PR TITLE
Tune Gemma4 local LLM for EVO-T1 settings

### DIFF
--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -10,9 +10,9 @@ data:
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
     ctx-size = 65536
     batch-size = 1024
-    ubatch-size = 256
-    threads = 12
-    threads-batch = 12
+    ubatch-size = 512
+    threads = 14
+    threads-batch = 14
 
     [ornith-35b]
     model = /models/ornith-1.0-35b-Q4_K_M.gguf


### PR DESCRIPTION
## Summary
- set Gemma4 ubatch-size to 512
- set Gemma4 threads and threads-batch to 14
- keep cpu-moe and q8_0 KV cache unchanged for stability

## Validation
- kubectl kustomize argoproj/local-llm
- kubectl apply --dry-run=server -k argoproj/local-llm
