### PR TITLE
Increase Gemma4 batch and ubatch sizes

### DIFF
--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -9,8 +9,8 @@ data:
     [gemma4-26b]
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
     ctx-size = 65536
-    batch-size = 1024
-    ubatch-size = 512
+    batch-size = 2048
+    ubatch-size = 1024
     threads = 14
     threads-batch = 14
 


### PR DESCRIPTION
## Summary
- increase Gemma4 batch-size from 1024 to 2048
- increase Gemma4 ubatch-size from 512 to 1024
- keep threads=14 and q8_0/cpu-moe stability settings unchanged

## Validation
- kubectl kustomize argoproj/local-llm
- kubectl apply --dry-run=server -k argoproj/local-llm
