### PR TITLE
Run local-llm on official SYCL image

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/local-llm.yaml
@@ -7,15 +7,15 @@ spec:
   applicationRefs:
     - namePattern: "local-llm"
       images:
-        - alias: "llama-vulkan"
-          imageName: "ghcr.io/boxp/arch/llama-vulkan:latest"
+        - alias: "llama-sycl"
+          imageName: "ghcr.io/boxp/arch/llama-sycl:latest"
           commonUpdateSettings:
             updateStrategy: "digest"
             platforms:
               - "linux/amd64"
           manifestTargets:
             kustomize:
-              name: "ghcr.io/boxp/arch/llama-vulkan"
+              name: "ghcr.io/boxp/arch/llama-sycl"
   writeBackConfig:
     method: "git:secret:argocd/repo-lolice"
     gitConfig:

--- a/argoproj/local-llm/.argocd-source-local-llm.yaml
+++ b/argoproj/local-llm/.argocd-source-local-llm.yaml
@@ -1,3 +1,3 @@
 kustomize:
   images:
-  - ghcr.io/boxp/arch/llama-vulkan=ghcr.io/boxp/arch/llama-vulkan:latest@sha256:f5045352fb474d567c069f4a72f3a1eb2cb57c3c00945501c1384a9e36135845
+  - ghcr.io/boxp/arch/llama-sycl=ghcr.io/boxp/arch/llama-sycl:latest@sha256:5c781ee682d4c8afa21799ad36a9229895663e32479f57aac3736cd2d8aac36a

--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           - 110
       containers:
         - name: llama-server
-          image: ghcr.io/boxp/arch/llama-vulkan:latest
+          image: ghcr.io/boxp/arch/llama-sycl:latest
           imagePullPolicy: Always
           args:
             - llama-server
@@ -38,7 +38,7 @@ spec:
             - --port
             - "8081"
             - -dev
-            - Vulkan0
+            - SYCL0
             - --models-preset
             - /config/models.ini
             - --models-max
@@ -65,6 +65,10 @@ spec:
               containerPort: 8081
           env:
             - name: ZES_ENABLE_SYSMAN
+              value: "1"
+            - name: ONEAPI_DEVICE_SELECTOR
+              value: level_zero:gpu
+            - name: ZE_ENABLE_PCI_ID_DEVICE_ORDER
               value: "1"
             - name: HOME
               value: /tmp

--- a/docs/project_docs/BOXP-23-local-llm-official-sycl/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-official-sycl/plan.md
@@ -1,0 +1,26 @@
+# BOXP-23 local-llm official SYCL rollout
+
+## Context
+
+`golyat-4` host direct verification showed that official `ggml-org/llama.cpp` commit `8c146a8366304c871efc26057cc90370ccf58dad` works with oneAPI 2026.0, Level Zero, and `SYCL0` on Intel Arc Graphics.
+
+`boxp/arch#10646` rebuilt `ghcr.io/boxp/arch/llama-sycl:latest` from that official source and published:
+
+- index digest: `sha256:5c781ee682d4c8afa21799ad36a9229895663e32479f57aac3736cd2d8aac36a`
+- linux/amd64 manifest: `sha256:5ec040afa0ce9ca046d3a0217b7217f1082dc6e9d54244c47acaf47dc2f801d6`
+
+## Plan
+
+1. Switch `local-llm` image back from `ghcr.io/boxp/arch/llama-vulkan:latest` to `ghcr.io/boxp/arch/llama-sycl:latest`.
+2. Pin the current Argo CD kustomize image state to the newly published `llama-sycl` digest.
+3. Switch runtime device from `Vulkan0` to `SYCL0`.
+4. Keep the current production model settings: `-ngl 99`, `-c 65536`, `--cache-type-k q8_0`, `--cache-type-v q8_0`, `--cpu-moe`, `--flash-attn on`, `--models-max 1`.
+5. Keep image digest ownership under `argocd-image-updater`, but change its target back to `llama-sycl`.
+6. Roll out through Argo CD and verify logs show `SYCL0` model/KV/compute buffers, readable Japanese output, and token/s.
+
+## Verification
+
+- `kubectl kustomize argoproj/local-llm`
+- `kubectl kustomize argoproj/argocd-image-updater`
+- server-side dry-run for both rendered manifests
+- production rollout smoke after merge


### PR DESCRIPTION
## Summary
- switch local-llm back to ghcr.io/boxp/arch/llama-sycl built from official ggml-org/llama.cpp
- switch runtime device from Vulkan0 to SYCL0 and set Level Zero selector env vars
- update local-llm ImageUpdater target and current Argo CD image digest

## Verification
- kubectl kustomize argoproj/local-llm
- kubectl kustomize argoproj/argocd-image-updater
- kubectl apply --dry-run=server for both rendered manifests
- host direct official SYCL smoke on golyat-4: readable Japanese, second-run prompt 29.11 tok/s, generation 9.57 tok/s