### PR TITLE
Add no-mmap to local-llm

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - -fa
             - "on"
             - --cpu-moe
+            - --no-mmap
             - --jinja
             - --reasoning
             - "off"

--- a/docs/project_docs/BOXP-23-local-llm-no-mmap/plan.md
+++ b/docs/project_docs/BOXP-23-local-llm-no-mmap/plan.md
@@ -1,0 +1,30 @@
+# BOXP-23 local-llm no-mmap
+
+## Context
+
+Production official SYCL `llama-server` works with `--cpu-moe`, but logs warn:
+
+```text
+tensor overrides to CPU are used with mmap enabled - consider using --no-mmap for better performance
+```
+
+The current production baseline is:
+
+- Long prompt eval: `29553 tokens / 28.18 tok/s`
+- Long generation: `335 tokens / 4.16 tok/s`
+- Short smoke generation: `8.92 tok/s`
+
+## Plan
+
+1. Add `--no-mmap` to the `local-llm` router args while keeping the current official SYCL settings.
+2. Render and server-side dry-run the `argoproj/local-llm` manifests.
+3. Merge through GitOps, wait for Argo CD to sync, and verify the running Pod args include `--no-mmap`.
+4. Reload Gemma4 and confirm the mmap warning disappears or changes.
+5. Run a Japanese smoke request and compare prompt/generation token rate against the current production baseline.
+
+## Validation
+
+- `kubectl kustomize argoproj/local-llm`
+- `kubectl apply --dry-run=server -k argoproj/local-llm`
+- Argo CD `local-llm` reaches `Synced Healthy`
+- Production `/v1/chat/completions` returns readable Japanese


### PR DESCRIPTION
## Summary
- add `--no-mmap` to the production local-llm llama-server args while keeping official SYCL settings
- document the plan and validation path for the no-mmap comparison

## Validation
- `git diff --check`
- `kubectl kustomize argoproj/local-llm`
- `kubectl apply --dry-run=server -k argoproj/local-llm`

Note: local `gitleaks` binary is not installed in this environment; PR CI runs the repository gitleaks workflow.