### PR TITLE
[codex] Add stable diffusion webui app

### DIFF
--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - kubernetes-dashboard/application.yaml
 - local-volume-provisioner/application.yaml
 - local-llm/application.yaml
+- stable-diffusion/application.yaml
 - longhorn/application.yaml
 - node-feature-discovery/application.yaml
 - intel-gpu-device-plugin/application.yaml

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - scrape-config.yaml
 - control-plane-node-rules.yaml
 - local-llm-gpu-observability-rules.yaml
+- stable-diffusion-observability-rules.yaml
 - cloudflared-pod-monitor.yaml
 - etcd-service.yaml
 - etcd-servicemonitor.yaml

--- a/argoproj/prometheus-operator/stable-diffusion-observability-rules.yaml
+++ b/argoproj/prometheus-operator/stable-diffusion-observability-rules.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: stable-diffusion-observability-rules
+  namespace: monitoring
+  labels:
+    prometheus: k8s
+    role: alert-rules
+    release: prometheus
+spec:
+  groups:
+    - name: stable-diffusion.rules
+      rules:
+        - alert: StableDiffusionWebuiPodMissing
+          expr: |
+            absent(kube_deployment_status_replicas_available{namespace="stable-diffusion", deployment="stable-diffusion-webui"})
+            or
+            kube_deployment_status_replicas_available{namespace="stable-diffusion", deployment="stable-diffusion-webui"} < 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Stable Diffusion WebUI pod is not available
+            description: stable-diffusion-webui has had no available replicas for more than 10 minutes.
+        - alert: StableDiffusionWebuiRestarting
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="stable-diffusion", container="sdnext"}[30m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Stable Diffusion WebUI container is restarting
+            description: The sdnext container restarted more than twice in 30 minutes.
+        - alert: StableDiffusionCloudflaredMissing
+          expr: |
+            absent(kube_deployment_status_replicas_available{namespace="stable-diffusion", deployment="stable-diffusion-cloudflared"})
+            or
+            kube_deployment_status_replicas_available{namespace="stable-diffusion", deployment="stable-diffusion-cloudflared"} < 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Stable Diffusion cloudflared pod is not available
+            description: stable-diffusion-cloudflared has had no available replicas for more than 10 minutes.
+

--- a/argoproj/stable-diffusion/application.yaml
+++ b/argoproj/stable-diffusion/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stable-diffusion
+  namespace: argocd
+spec:
+  destination:
+    namespace: stable-diffusion
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: argoproj/stable-diffusion
+    repoURL: https://github.com/boxp/lolice
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+

--- a/argoproj/stable-diffusion/cloudflared-deployment.yaml
+++ b/argoproj/stable-diffusion/cloudflared-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stable-diffusion-cloudflared
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+        - name: cloudflared
+          image: docker.io/cloudflare/cloudflared:2026.6.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - tunnel
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+            - --protocol
+            - http2
+            - --token
+            - $(TUNNEL_TOKEN)
+          ports:
+            - name: metrics
+              containerPort: 2000
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          envFrom:
+            - secretRef:
+                name: stable-diffusion-cloudflared-secret
+

--- a/argoproj/stable-diffusion/deployment.yaml
+++ b/argoproj/stable-diffusion/deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stable-diffusion-webui
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: stable-diffusion-webui
+  template:
+    metadata:
+      labels:
+        app: stable-diffusion-webui
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        lolice.io/gpu-worker: "true"
+      tolerations:
+        - key: lolice.io/gpu-worker
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+        supplementalGroups:
+          - 44
+          - 110
+      containers:
+        - name: sdnext
+          image: ghcr.io/boxp/arch/sdnext-ipex:latest
+          imagePullPolicy: Always
+          args:
+            - --use-ipex
+            - --listen
+            - --server-name
+            - 0.0.0.0
+            - --port
+            - "7860"
+            - --uv
+            - --api
+            - --log
+            - /scratch/sdnext.log
+          ports:
+            - name: http
+              containerPort: 7860
+          env:
+            - name: SD_DATADIR
+              value: /data
+            - name: SD_MODELSDIR
+              value: /data/models
+            - name: HF_HOME
+              value: /scratch/huggingface
+            - name: XDG_CACHE_HOME
+              value: /scratch/cache
+            - name: TMPDIR
+              value: /scratch/tmp
+            - name: ONEAPI_DEVICE_SELECTOR
+              value: level_zero:gpu
+            - name: ZE_ENABLE_PCI_ID_DEVICE_ORDER
+              value: "1"
+          resources:
+            requests:
+              cpu: "4"
+              memory: 24Gi
+              gpu.intel.com/i915: "1"
+            limits:
+              cpu: "14"
+              memory: 80Gi
+              gpu.intel.com/i915: "1"
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: scratch
+              mountPath: /scratch
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: sd-webui-data
+        - name: scratch
+          hostPath:
+            path: /var/lib/stable-diffusion-webui/scratch
+            type: DirectoryOrCreate

--- a/argoproj/stable-diffusion/external-secret.yaml
+++ b/argoproj/stable-diffusion/external-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-secret-stable-diffusion-cloudflared
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: stable-diffusion-cloudflared-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: TUNNEL_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: stable-diffusion-tunnel-token
+        metadataPolicy: None
+

--- a/argoproj/stable-diffusion/kustomization.yaml
+++ b/argoproj/stable-diffusion/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: stable-diffusion
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - cloudflared-deployment.yaml
+  - external-secret.yaml
+  - networkpolicy.yaml

--- a/argoproj/stable-diffusion/namespace.yaml
+++ b/argoproj/stable-diffusion/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stable-diffusion
+

--- a/argoproj/stable-diffusion/networkpolicy.yaml
+++ b/argoproj/stable-diffusion/networkpolicy.yaml
@@ -1,0 +1,48 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: stable-diffusion-webui
+spec:
+  selector: app == 'stable-diffusion-webui'
+  types:
+    - Ingress
+    - Egress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      source:
+        namespaceSelector: kubernetes.io/metadata.name == 'stable-diffusion'
+        selector: app == 'cloudflared'
+      destination:
+        ports:
+          - 7860
+    - action: Allow
+      protocol: TCP
+      source:
+        nets:
+          - 192.168.10.0/24
+      destination:
+        ports:
+          - 7860
+  egress:
+    - action: Allow
+      protocol: UDP
+      destination:
+        selector: k8s-app == 'kube-dns'
+        namespaceSelector: kubernetes.io/metadata.name == 'kube-system'
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: k8s-app == 'kube-dns'
+        namespaceSelector: kubernetes.io/metadata.name == 'kube-system'
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - 80
+          - 443
+

--- a/argoproj/stable-diffusion/pvc.yaml
+++ b/argoproj/stable-diffusion/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sd-webui-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ssd-storage
+  resources:
+    requests:
+      storage: 128Gi
+

--- a/argoproj/stable-diffusion/service.yaml
+++ b/argoproj/stable-diffusion/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stable-diffusion-webui
+  labels:
+    app: stable-diffusion-webui
+spec:
+  selector:
+    app: stable-diffusion-webui
+  ports:
+    - name: http
+      port: 7860
+      targetPort: http
+


### PR DESCRIPTION
## Summary
- Add an Argo CD application for `stable-diffusion`.
- Add PVC-backed SD.Next deployment, service, Cloudflare tunnel pod, ExternalSecret, and Calico NetworkPolicy.
- Add Prometheus alert rules for WebUI and tunnel pod presence/restarts.

## Impact
This prepares the cluster side for hosting Stable Diffusion WebUI on a GPU worker, with models/LoRA/saved outputs on `sd-webui-data` PVC and transient scratch/log/cache data on local disk.

## Validation
- `kubectl kustomize argoproj/stable-diffusion >/tmp/lolice-stable-diffusion.yaml`
- `kubectl kustomize argoproj >/tmp/lolice-argoproj.yaml`
- `kubectl kustomize argoproj/prometheus-operator >/tmp/lolice-prometheus.yaml`
- `git diff --check`

Kustomize reports only existing deprecated `patchesJson6902`/`patchesStrategicMerge` warnings from the repository.