### PR TITLE
Manage Stable Diffusion image updates

### DIFF
--- a/.claude/skills/lolice-image-updater/SKILL.md
+++ b/.claude/skills/lolice-image-updater/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: lolice-image-updater
+description: Use when changing container images in boxp/lolice Kubernetes manifests, adding a new workload image, or discussing image rollout ownership; enforces Argo CD Image Updater ownership instead of manual tag or digest edits.
+---
+
+# lolice Image Updater
+
+For `boxp/lolice`, do not hand-edit workload image tags or digests as the rollout mechanism. Container image updates are owned by Argo CD Image Updater whenever the image is built outside this repo or should continuously follow a registry tag.
+
+## Workflow
+
+1. Check existing ImageUpdater patterns:
+   - `argoproj/argocd-image-updater/imageupdaters/*.yaml`
+   - `argoproj/argocd-image-updater/imageupdaters/kustomization.yaml`
+2. Keep the workload manifest image at the logical registry/tag, usually `ghcr.io/boxp/arch/<image>:latest` or the ECR `...amazonaws.com/<image>:latest`.
+3. Add or update an `ImageUpdater` resource for the Argo CD Application.
+4. Use `writeBackConfig.method: git:secret:argocd/repo-lolice` and target `branch: main`.
+5. Choose registry-specific settings:
+   - GHCR `boxp/arch` images: follow `local-llm.yaml`; use `updateStrategy: digest`, set `platforms: ["linux/amd64"]`, and set `gitConfig.repository: git@github.com:boxp/lolice.git`.
+   - ECR images: follow `ark-discord-bot.yaml` / `palserver.yaml`; use `updateStrategy: newest-build` and `pullSecret: pullsecret:argocd/regcred`.
+6. Set `manifestTargets.kustomize.name` to the image name without tag.
+7. Validate with:
+   - `kubectl kustomize argoproj/argocd-image-updater`
+   - `kubectl kustomize argoproj/<application>`
+
+## Guardrails
+
+- Do not pin generated `sha-*` tags manually in workload manifests.
+- Do not commit Image Updater write-back output unless the task is specifically to inspect or repair it.
+- If changing runtime args/resources for a workload, make that manifest change separately from image rollout ownership.

--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - even-g2-lab.yaml
   - codex-workspace.yaml
   - local-llm.yaml
+  - stable-diffusion.yaml

--- a/argoproj/argocd-image-updater/imageupdaters/stable-diffusion.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/stable-diffusion.yaml
@@ -1,0 +1,23 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: stable-diffusion
+  namespace: argocd
+spec:
+  applicationRefs:
+    - namePattern: "stable-diffusion"
+      images:
+        - alias: "sdnext-ipex"
+          imageName: "ghcr.io/boxp/arch/sdnext-ipex:latest"
+          commonUpdateSettings:
+            updateStrategy: "digest"
+            platforms:
+              - "linux/amd64"
+          manifestTargets:
+            kustomize:
+              name: "ghcr.io/boxp/arch/sdnext-ipex"
+  writeBackConfig:
+    method: "git:secret:argocd/repo-lolice"
+    gitConfig:
+      repository: "git@github.com:boxp/lolice.git"
+      branch: "main"

--- a/argoproj/stable-diffusion/deployment.yaml
+++ b/argoproj/stable-diffusion/deployment.yaml
@@ -38,7 +38,10 @@ spec:
             - 0.0.0.0
             - --port
             - "7860"
-            - --uv
+            - --skip-git
+            - --skip-requirements
+            - --skip-extensions
+            - --skip-torch
             - --api
             - --log
             - /scratch/sdnext.log


### PR DESCRIPTION
## Summary
- remove runtime `--uv` install path from Stable Diffusion deployment
- add runtime skip flags for git, requirements, extensions, and torch installation
- add Argo CD Image Updater ownership for ghcr.io/boxp/arch/sdnext-ipex:latest
- add a lolice skill documenting ImageUpdater ownership and GHCR/ECR patterns

## Validation
- kubectl kustomize argoproj/argocd-image-updater
- kubectl kustomize argoproj/stable-diffusion
- python3 /home/boxp/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/lolice-image-updater