### PR TITLE
feat: deploy only local-llm, keep stable-diffusion at replicas: 0

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: llama-server
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:

--- a/argoproj/stable-diffusion/cloudflared-deployment.yaml
+++ b/argoproj/stable-diffusion/cloudflared-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: stable-diffusion-cloudflared
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: cloudflared


### PR DESCRIPTION
## What
GPU リソースの競合により、local-llm と stable-diffusion のどちらかしか同時に稼働できません。

## Changes
- **local-llm** (selected): `replicas: 0` → `replicas: 1`
- **stable-diffusion** (not selected): `replicas: 0` (unchanged)
- **stable-diffusion cloudflared**: `replicas: 1` → `replicas: 0` (stable-diffusion が稼働しないため tunnel 不要)

## Rationale
single GPU worker node (Intel Arc) 上で両サービスが並行稼働できないため、local-llm を優先してデプロイします。