### PR TITLE
remove codex workspace in-pod warp

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -101,25 +101,6 @@ spec:
                   key: GEMINI_API_KEY
             - name: PI_CODING_AGENT_DIR
               value: /home/boxp/.pi/agent
-            - name: CLOUDFLARE_WARP_ENABLED
-              value: "true"
-            - name: CLOUDFLARE_WARP_REQUIRED
-              value: "false"
-            - name: CLOUDFLARE_WARP_AUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: codex-workspace-cloudflare-warp
-                  key: auth-client-id
-            - name: CLOUDFLARE_WARP_AUTH_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: codex-workspace-cloudflare-warp
-                  key: auth-client-secret
-            - name: CLOUDFLARE_WARP_ORGANIZATION
-              valueFrom:
-                secretKeyRef:
-                  name: codex-workspace-cloudflare-warp
-                  key: organization
             - name: DOCKER_HOST
               value: tcp://127.0.0.1:2375
             - name: DOCKER_BUILDKIT
@@ -172,8 +153,6 @@ spec:
               mountPath: /usr/local/bin/docker
               subPath: docker
               readOnly: true
-            - name: dev-net-tun
-              mountPath: /dev/net/tun
         - name: obsidian-sync
           image: ghcr.io/boxp/arch/codex-workspace:latest
           imagePullPolicy: Always
@@ -290,7 +269,3 @@ spec:
           emptyDir: {}
         - name: docker-graph-storage
           emptyDir: {}
-        - name: dev-net-tun
-          hostPath:
-            path: /dev/net/tun
-            type: CharDevice

--- a/argoproj/codex-workspace/external-secret.yaml
+++ b/argoproj/codex-workspace/external-secret.yaml
@@ -51,27 +51,3 @@ spec:
     - secretKey: GEMINI_API_KEY
       remoteRef:
         key: /lolice/codex-workspace/gemini-api-key
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: codex-workspace-cloudflare-warp
-  namespace: codex-workspace
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: parameterstore
-    kind: ClusterSecretStore
-  target:
-    name: codex-workspace-cloudflare-warp
-    creationPolicy: Owner
-  data:
-    - secretKey: auth-client-id
-      remoteRef:
-        key: /lolice/codex-workspace/cloudflare-warp-auth-client-id
-    - secretKey: auth-client-secret
-      remoteRef:
-        key: /lolice/codex-workspace/cloudflare-warp-auth-client-secret
-    - secretKey: organization
-      remoteRef:
-        key: /lolice/codex-workspace/cloudflare-warp-organization

--- a/docs/project_docs/remove-codex-workspace-warp/plan.md
+++ b/docs/project_docs/remove-codex-workspace-warp/plan.md
@@ -1,0 +1,58 @@
+# Remove codex-workspace in-pod WARP client
+
+## Problem
+
+`codex-workspace` was unreachable through its kube-vip LoadBalancer VIP `192.168.10.98`.
+
+After fixing kube-vip EndpointSlice RBAC, the VIP was advertised again, but `192.168.10.98:22` still failed while other Service VIPs worked.
+
+## Findings
+
+- kube-vip advertised `192.168.10.98`; ARP resolved successfully.
+- The `codex-workspace` Service and EndpointSlice were healthy.
+- Packets from `shanghai-*` nodes reached the `golyat-3` host and were forwarded to the `codex-workspace` Pod veth.
+- The Pod did not emit SYN-ACK for those connections.
+- A same-node temporary Pod with comparable Calico policy was reachable from `shanghai-2`, so the failure was specific to the `codex-workspace` Pod network namespace.
+- Running `warp-cli disconnect` inside the `codex-workspace` workspace container immediately restored:
+  - `192.168.10.98:22`
+  - `192.168.10.103:31540`
+  - cloudflared-to-`192.168.10.98:22`
+  - Windows WARP-to-`192.168.10.98:22`
+
+## Root Cause
+
+The Cloudflare WARP client running inside the `codex-workspace` Pod changed the Pod network namespace in a way that broke replies for inbound cluster/LAN traffic.
+
+WARP is only needed on the client side for this access path:
+
+```text
+WARP client -> Cloudflare -> k8s cloudflared -> codex-workspace Service
+```
+
+Running an additional WARP client inside the target Pod is harmful for this workload.
+
+## Fix
+
+Remove in-pod WARP startup inputs from `codex-workspace`:
+
+- remove WARP environment variables
+- remove the WARP ExternalSecret
+- remove `/dev/net/tun` hostPath and mount
+
+The image may still contain `cloudflare-warp`, but the Pod will no longer start or configure the client because `CLOUDFLARE_WARP_ENABLED` is absent and defaults to disabled.
+
+## Verification
+
+After Argo CD sync:
+
+```sh
+kubectl -n codex-workspace rollout status deployment/codex-workspace --timeout=240s
+kubectl -n codex-workspace exec deploy/codex-workspace -c workspace -- sh -c 'pgrep -a warp-svc || true; warp-cli status || true; ip rule'
+```
+
+Expected:
+
+- no `warp-svc` process
+- no WARP policy routing rule
+- `192.168.10.98:22` succeeds from WARP client side
+- `cloudflared` Pod can connect to `192.168.10.98:22`


### PR DESCRIPTION
## Summary

- Remove Cloudflare WARP startup inputs from the `codex-workspace` Pod.
- Remove the WARP ExternalSecret and `/dev/net/tun` hostPath mount.
- Document the investigation and verification plan.

## Root cause

The Cloudflare WARP client running inside the target `codex-workspace` Pod changed the Pod network namespace and broke replies for inbound kube-vip/NodePort traffic. Disconnecting WARP inside the Pod immediately restored `192.168.10.98:22`, shanghai NodePort access, and cloudflared-to-VIP access.

The external access path only needs WARP on the client side:

```text
WARP client -> Cloudflare -> k8s cloudflared -> codex-workspace Service
```

Running WARP inside the destination Pod is harmful for this workload.

## Verification

```sh
kubectl apply --dry-run=server -k argoproj/codex-workspace
```

