### PR TITLE
Add task board draft watcher sidecar

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -184,6 +184,44 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
+        - name: obsidian-task-board-draft
+          image: ghcr.io/boxp/arch/codex-workspace:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              watch_script="${OBSIDIAN_VAULT_PATH}/Scripts/task-board-draft-watch.sh"
+              while [ ! -f "${watch_script}" ]; do
+                echo "Waiting for ${watch_script}"
+                sleep 5
+              done
+              exec /bin/bash "${watch_script}"
+          env:
+            - name: HOME
+              value: /home/boxp
+            - name: OBSIDIAN_VAULT_PATH
+              value: /home/boxp/Documents/obsidian-headless/BOXP
+            - name: TASK_BOARD_DRAFT_WATCH_INTERVAL
+              value: "1"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"
+          volumeMounts:
+            - name: home
+              mountPath: /home/boxp
         - name: docker
           image: docker.io/docker:29.6.1-dind
           imagePullPolicy: IfNotPresent

--- a/docs/project_docs/task-board-draft-sidecar/plan.md
+++ b/docs/project_docs/task-board-draft-sidecar/plan.md
@@ -1,0 +1,21 @@
+# Task Board Draft Sidecar
+
+## Goal
+
+Codex workspace Pod の再起動後も Obsidian Task Board の Draft 取り込み watcher が自動で起動するようにする。
+
+## Plan
+
+- `argoproj/codex-workspace/deployment.yaml` に `obsidian-task-board-draft` sidecar を追加する。
+- sidecar は既存の home PVC を `/home/boxp` に mount し、vault 上の `Scripts/task-board-draft-watch.sh` を実行する。
+- vault sync のタイミングに依存しないよう、watcher script が作成されるまで 5 秒間隔で待つ。
+- Obsidian Sync が実行ビットを保持しない場合に備え、sidecar は watcher を `/bin/bash` 経由で起動する。
+- systemd / tmux には依存しない。Kubernetes の Pod lifecycle に任せる。
+
+## Verification
+
+- `kubectl kustomize argoproj/codex-workspace`
+
+## Local Notes
+
+- 2026-06-30: この codex-workspace には `kubectl` / `kustomize` が無いため、manifest build は未実行。`git diff --check` は成功。


### PR DESCRIPTION
## Summary

- Add an `obsidian-task-board-draft` sidecar to the Codex workspace Deployment.
- Run the Obsidian Task Board draft watcher from the shared home PVC so it survives Pod restarts.
- Document the sidecar plan under `docs/project_docs/task-board-draft-sidecar/plan.md`.

## Notes

The sidecar waits for `Documents/obsidian-headless/BOXP/Scripts/task-board-draft-watch.sh` to appear, then runs it via `/bin/bash` so it does not depend on Obsidian Sync preserving executable bits.

## Validation

- `git diff --check`
- Not run: `kubectl kustomize argoproj/codex-workspace` because this codex-workspace does not currently have `kubectl` or `kustomize` installed.
