### PR TITLE
[codex] BOXP-23 gemma4 context 256k

### DIFF
--- a/argoproj/codex-workspace/configmap.yaml
+++ b/argoproj/codex-workspace/configmap.yaml
@@ -40,7 +40,7 @@ data:
               "name": "Gemma4 26B local",
               "reasoning": false,
               "input": ["text"],
-              "contextWindow": 131072,
+              "contextWindow": 262144,
               "maxTokens": 4096,
               "cost": {
                 "input": 0,

--- a/argoproj/codex-workspace/configmap.yaml
+++ b/argoproj/codex-workspace/configmap.yaml
@@ -40,7 +40,7 @@ data:
               "name": "Gemma4 26B local",
               "reasoning": false,
               "input": ["text"],
-              "contextWindow": 65536,
+              "contextWindow": 131072,
               "maxTokens": 4096,
               "cost": {
                 "input": 0,

--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - -ngl
             - "99"
             - -c
-            - "131072"
+            - "262144"
             - --parallel
             - "1"
             - --cache-type-k

--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - -ngl
             - "99"
             - -c
-            - "65536"
+            - "131072"
             - --parallel
             - "1"
             - --cache-type-k

--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -8,7 +8,7 @@ data:
 
     [gemma4-26b]
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
-    ctx-size = 131072
+    ctx-size = 262144
     batch-size = 2048
     ubatch-size = 1024
     threads = 14

--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -8,7 +8,7 @@ data:
 
     [gemma4-26b]
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
-    ctx-size = 65536
+    ctx-size = 131072
     batch-size = 2048
     ubatch-size = 1024
     threads = 14

--- a/docs/project_docs/BOXP-23-gemma4-context-128k/plan.md
+++ b/docs/project_docs/BOXP-23-gemma4-context-128k/plan.md
@@ -1,0 +1,21 @@
+# BOXP-23 Gemma4 128k context
+
+## Context
+
+`local-llm` currently exposes `gemma4-26b` with a 65536 token context in both the llama-server model preset and the `codex-workspace` pi model metadata.
+
+Gemma4 should be available with a 128k context window while keeping the existing Ornith 65536 setting unchanged.
+
+## Plan
+
+1. Set the `gemma4-26b` llama-server model preset `ctx-size` to `131072`.
+2. Align the llama-server startup `-c` value with the larger Gemma4 context.
+3. Update the `codex-workspace` pi config so only `gemma4-26b` advertises `contextWindow=131072`.
+4. Validate the YAML and embedded pi `models.json`.
+
+## Verification
+
+- `python - <<'PY' ... yaml.safe_load_all(...) ... PY`
+- `python - <<'PY' ... json.loads(models.json) ... PY`
+- `kubectl kustomize argoproj/local-llm >/tmp/lolice-local-llm.yaml`
+- `kubectl kustomize argoproj/codex-workspace >/tmp/lolice-codex-workspace.yaml`

--- a/docs/project_docs/BOXP-23-gemma4-context-256k/plan.md
+++ b/docs/project_docs/BOXP-23-gemma4-context-256k/plan.md
@@ -1,16 +1,16 @@
-# BOXP-23 Gemma4 128k context
+# BOXP-23 Gemma4 256k context
 
 ## Context
 
 `local-llm` currently exposes `gemma4-26b` with a 65536 token context in both the llama-server model preset and the `codex-workspace` pi model metadata.
 
-Gemma4 should be available with a 128k context window while keeping the existing Ornith 65536 setting unchanged.
+Gemma4 should be available with a 256k context window while keeping the existing Ornith 65536 setting unchanged.
 
 ## Plan
 
-1. Set the `gemma4-26b` llama-server model preset `ctx-size` to `131072`.
+1. Set the `gemma4-26b` llama-server model preset `ctx-size` to `262144`.
 2. Align the llama-server startup `-c` value with the larger Gemma4 context.
-3. Update the `codex-workspace` pi config so only `gemma4-26b` advertises `contextWindow=131072`.
+3. Update the `codex-workspace` pi config so only `gemma4-26b` advertises `contextWindow=262144`.
 4. Validate the YAML and embedded pi `models.json`.
 
 ## Verification


### PR DESCRIPTION
## Summary

- Increase the `gemma4-26b` llama-server preset context from 65536 to 262144.
- Align the llama-server startup `-c` value with the Gemma4 256k context.
- Advertise `gemma4-26b` as 262144 context in the codex-workspace pi config while leaving `ornith-35b` at 65536.
- Move the project plan to `docs/project_docs/BOXP-23-gemma4-context-256k/plan.md`.

## Verification

- `git diff --check`
- YAML parse for `argoproj/local-llm/models-config.yaml`, `argoproj/local-llm/deployment.yaml`, and `argoproj/codex-workspace/configmap.yaml`
- Embedded pi `models.json` parse confirms `gemma4-26b: 262144` and `ornith-35b: 65536`
- `kubectl kustomize argoproj/local-llm >/tmp/lolice-local-llm.yaml`
- `kubectl kustomize argoproj/codex-workspace >/tmp/lolice-codex-workspace.yaml`