### PR TITLE
[codex] Deploy hitohako agent sidecar

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -222,6 +222,52 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
+        - name: hitohako-agent
+          image: 839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/hitohako-agent-main:latest
+          imagePullPolicy: Always
+          ports:
+            - name: hitohako-agent
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: HITOHAKO_VAULT_PATH
+              value: /home/boxp/Documents/obsidian-headless/BOXP
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: codex-workspace-gemini
+                  key: GEMINI_API_KEY
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: hitohako-agent
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: hitohako-agent
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: home
+              mountPath: /home/boxp
         - name: docker
           image: docker.io/docker:29.6.1-dind
           imagePullPolicy: IfNotPresent

--- a/argoproj/codex-workspace/networkpolicy.yaml
+++ b/argoproj/codex-workspace/networkpolicy.yaml
@@ -18,6 +18,7 @@ spec:
         ports:
           - 2222
           - 3456
+          - 8080
     - action: Allow
       protocol: TCP
       source:
@@ -27,6 +28,7 @@ spec:
         ports:
           - 2222
           - 3456
+          - 8080
   egress:
     - action: Allow
       protocol: UDP

--- a/argoproj/codex-workspace/service.yaml
+++ b/argoproj/codex-workspace/service.yaml
@@ -15,3 +15,6 @@ spec:
     - name: even-terminal
       port: 3456
       targetPort: even-terminal
+    - name: hitohako-agent
+      port: 8080
+      targetPort: hitohako-agent

--- a/docs/project_docs/BOXP-9-hitohako-agent/plan.md
+++ b/docs/project_docs/BOXP-9-hitohako-agent/plan.md
@@ -1,0 +1,38 @@
+# BOXP-9: hitohako-agent on Even G2
+
+## Goal
+
+Even G2 の PC-98 風クライアントから、lolice 上の `hitohako-agent` backend に問い合わせ、Obsidian Headless で同期された Vault を参照しながら短い応答を返せる MVP にする。
+
+## Architecture
+
+```text
+Even G2 app
+  -> VITE_HITOHAKO_AGENT_ENDPOINT /v1/chat
+  -> codex-workspace Pod sidecar: hitohako-agent
+  -> shared /home/boxp PVC
+  -> /home/boxp/Documents/obsidian-headless/BOXP
+  -> obsidian-sync sidecar
+```
+
+## Implementation Plan
+
+- `boxp/even-g2-lab`
+  - `apps/hitohako-agent` を追加し、`POST /v1/chat` と `GET /healthz` を提供する。
+  - backend は Vault の `キャラ設定/ひとはこ.md`、当日 daily note、`ひとはこ/*.md` を read し、G2 向け短文応答を生成する。
+  - 会話ログは `Captures/hitohako-agent/YYYY-MM-DD.md` への append に限定する。
+  - G2 client は `VITE_HITOHAKO_AGENT_MODE=api` のときだけ backend API を使い、未設定時は明示 mock のままにする。
+- `boxp/lolice`
+  - `codex-workspace` Pod に `hitohako-agent` sidecar を追加し、既存 home PVC と Obsidian Headless sidecar を共有する。
+  - Service と NetworkPolicy に `hitohako-agent` port 8080 を追加する。
+  - API key は既存 ExternalSecret `codex-workspace-gemini` から注入し、Git には置かない。
+
+## Validation
+
+- `boxp/even-g2-lab`: `npm test`, `npm run typecheck`
+- `boxp/lolice`: `kubectl kustomize argoproj/codex-workspace`
+
+## Follow-up
+
+- `hitohako-agent-main` image の publish workflow と ECR repository の存在確認。
+- 実機 G2 では画像更新頻度を抑え、backend 応答表示中の口パクは「発言中だけ開口」程度に留める。


### PR DESCRIPTION
## Summary

- Add a `hitohako-agent` sidecar to the `codex-workspace` Pod.
- Share the existing `/home/boxp` PVC with the Obsidian Headless sync sidecar so the backend can read/write the synced Vault.
- Expose port 8080 through the codex-workspace Service and NetworkPolicy.
- Inject `GEMINI_API_KEY` from the existing `codex-workspace-gemini` Secret instead of committing any secret material.
- Include the BOXP-9 deployment plan under `docs/project_docs/BOXP-9-hitohako-agent/plan.md`.

## Validation

- `kustomize build argoproj/codex-workspace` using a temporary Kustomize v5.7.1 binary

## Notes

- The `hitohako-agent-main` ECR repository/image availability and Argo CD sync should be checked during review/deploy.
- Runtime behavior with the real Even G2 app still needs human/device review.
