### PR TITLE
Fix Even G2 image updater writeback

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/even-g2-lab.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/even-g2-lab.yaml
@@ -18,4 +18,5 @@ spec:
   writeBackConfig:
     method: "git:secret:argocd/repo-lolice"
     gitConfig:
+      repository: "git@github.com:boxp/lolice.git"
       branch: "main"

--- a/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
+++ b/docs/project_docs/BOXP-17-even-g2-main-deploy/plan.md
@@ -20,6 +20,7 @@
 - [x] Add Deployment/ClusterIP Service/NetworkPolicy for main static app.
 - [x] Add dedicated `cloudflared` Deployment and ExternalSecret in `even-g2-lab`.
 - [x] Add ImageUpdater resource for ECR image updates.
+- [x] Set the ImageUpdater git write-back repository explicitly.
 - [x] Validate YAML manifests.
 - [ ] After merge/apply, confirm `regcred` exists in `even-g2-lab` namespace.
 - [ ] Confirm `even-g2-lab` `cloudflared` can route `even-g2-main.b0xp.io` to `http://even-g2-main.even-g2-lab.svc.cluster.local:80`.


### PR DESCRIPTION
## Summary
- set the Even G2 ImageUpdater git write-back repository explicitly
- update the BOXP-17 deployment plan with the follow-up fix

## Context
The main image workflow now succeeds, but lolice has no ImageUpdater write-back commit for even-g2-lab and the deployment manifest still points at the bootstrap tag. This matches the earlier codex-workspace ImageUpdater issue fixed by adding gitConfig.repository.

## Validation
- git diff --check
- confirmed other ImageUpdater resources use gitConfig.repository with git@github.com:boxp/lolice.git

## Remaining verification after merge
- confirm ImageUpdater writes back the selected even-g2-client-main tag
- confirm the phone connected to Cloudflare WARP can load https://even-g2-main.b0xp.io/ through Even Realities App QR sideloading