### PR TITLE
[codex] Add codex workspace read-only kubectl access

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: codex-workspace
     spec:
+      serviceAccountName: codex-workspace
       automountServiceAccountToken: false
       nodeSelector:
         kubernetes.io/arch: amd64
@@ -105,6 +106,8 @@ spec:
               value: tcp://127.0.0.1:2375
             - name: DOCKER_BUILDKIT
               value: "1"
+            - name: KUBECONFIG
+              value: /var/run/secrets/codex-workspace/kubeconfig/config
           securityContext:
             privileged: true
             runAsNonRoot: false
@@ -152,6 +155,12 @@ spec:
             - name: docker-cli
               mountPath: /usr/local/bin/docker
               subPath: docker
+              readOnly: true
+            - name: kubeconfig
+              mountPath: /var/run/secrets/codex-workspace/kubeconfig
+              readOnly: true
+            - name: kubernetes-api-token
+              mountPath: /var/run/secrets/codex-workspace/k8s
               readOnly: true
         - name: obsidian-sync
           image: ghcr.io/boxp/arch/codex-workspace:latest
@@ -275,6 +284,8 @@ spec:
                 secretKeyRef:
                   name: codex-workspace-gemini
                   key: GEMINI_API_KEY
+            - name: KUBECONFIG
+              value: /var/run/secrets/codex-workspace/kubeconfig/config
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -293,6 +304,12 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
+            - name: kubeconfig
+              mountPath: /var/run/secrets/codex-workspace/kubeconfig
+              readOnly: true
+            - name: kubernetes-api-token
+              mountPath: /var/run/secrets/codex-workspace/k8s
+              readOnly: true
         - name: task-board-runner
           image: ghcr.io/boxp/arch/codex-workspace:latest
           imagePullPolicy: Always
@@ -316,6 +333,8 @@ spec:
               value: tcp://127.0.0.1:2375
             - name: DOCKER_BUILDKIT
               value: "1"
+            - name: KUBECONFIG
+              value: /var/run/secrets/codex-workspace/kubeconfig/config
             - name: GRAFANA_URL
               value: http://grafana.monitoring.svc.cluster.local:3000
             - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
@@ -350,6 +369,12 @@ spec:
               mountPath: /usr/local/bin/docker
               subPath: docker
               readOnly: true
+            - name: kubeconfig
+              mountPath: /var/run/secrets/codex-workspace/kubeconfig
+              readOnly: true
+            - name: kubernetes-api-token
+              mountPath: /var/run/secrets/codex-workspace/k8s
+              readOnly: true
       volumes:
         - name: home
           persistentVolumeClaim:
@@ -364,3 +389,23 @@ spec:
           emptyDir: {}
         - name: docker-graph-storage
           emptyDir: {}
+        - name: kubeconfig
+          configMap:
+            name: codex-workspace-kubeconfig
+        - name: kubernetes-api-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+                  audience: https://kubernetes.default.svc
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        fieldPath: metadata.namespace

--- a/argoproj/codex-workspace/kubeconfig.yaml
+++ b/argoproj/codex-workspace/kubeconfig.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: codex-workspace-kubeconfig
+  namespace: codex-workspace
+data:
+  config: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: in-cluster
+        cluster:
+          server: https://kubernetes.default.svc
+          certificate-authority: /var/run/secrets/codex-workspace/k8s/ca.crt
+    users:
+      - name: codex-workspace
+        user:
+          tokenFile: /var/run/secrets/codex-workspace/k8s/token
+    contexts:
+      - name: in-cluster
+        context:
+          cluster: in-cluster
+          namespace: codex-workspace
+          user: codex-workspace
+    current-context: in-cluster

--- a/argoproj/codex-workspace/kustomization.yaml
+++ b/argoproj/codex-workspace/kustomization.yaml
@@ -3,9 +3,12 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - service-account.yaml
+  - rbac.yaml
   - storageclass.yaml
   - pvc.yaml
   - configmap.yaml
+  - kubeconfig.yaml
   - external-secret.yaml
   - deployment.yaml
   - service.yaml

--- a/argoproj/codex-workspace/rbac.yaml
+++ b/argoproj/codex-workspace/rbac.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: codex-workspace-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - componentstatuses
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - admissionregistration.k8s.io
+      - apiextensions.k8s.io
+      - apiregistration.k8s.io
+      - apps
+      - argocd-image-updater.argoproj.io
+      - argoproj.io
+      - autoscaling
+      - batch
+      - certificates.k8s.io
+      - coordination.k8s.io
+      - discovery.k8s.io
+      - events.k8s.io
+      - external-secrets.io
+      - flowcontrol.apiserver.k8s.io
+      - longhorn.io
+      - monitoring.coreos.com
+      - networking.k8s.io
+      - node.k8s.io
+      - pingcap.com
+      - policy
+      - projectcalico.org
+      - rbac.authorization.k8s.io
+      - scheduling.k8s.io
+      - storage.k8s.io
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: codex-workspace-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: codex-workspace-read
+subjects:
+  - kind: ServiceAccount
+    name: codex-workspace
+    namespace: codex-workspace

--- a/argoproj/codex-workspace/service-account.yaml
+++ b/argoproj/codex-workspace/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: codex-workspace
+  namespace: codex-workspace
+automountServiceAccountToken: false

--- a/docs/project_docs/BOXP-37-codex-workspace-kubectl-rbac/plan.md
+++ b/docs/project_docs/BOXP-37-codex-workspace-kubectl-rbac/plan.md
@@ -1,0 +1,107 @@
+# BOXP-37 codex-workspace kubectl RBAC
+
+## 目的
+
+Codex workspace から Kubernetes manifest の事前確認と cluster 状態の読み取り調査をできるようにする。
+`kubectl` / `kustomize` は workspace image 側で利用可能な前提とし、この変更では `boxp/lolice` の GitOps manifest に in-cluster 接続用の ServiceAccount、kubeconfig、RBAC、mount を追加する。
+
+## 実装計画
+
+- `codex-workspace` namespace に専用 ServiceAccount `codex-workspace` を追加する。
+- Pod の `automountServiceAccountToken: false` は維持し、明示的な projected volume で短期 ServiceAccount token、`kube-root-ca.crt`、namespace を mount する。
+- ConfigMap `codex-workspace-kubeconfig` を追加し、`tokenFile` と cluster CA を参照する in-cluster kubeconfig を提供する。
+- `workspace` container、`codex-cron-scheduler` container、`task-board-runner` container に `KUBECONFIG=/var/run/secrets/codex-workspace/kubeconfig/config` と read-only mount を追加する。
+- `secrets` を除く core resource と、リポジトリで利用している主要 API group / Kubernetes 標準 API group に `get`, `list`, `watch` のみを付与する ClusterRole / ClusterRoleBinding を追加する。
+
+## 権限範囲
+
+許可する操作:
+
+- core API group の `pods`, `services`, `configmaps`, `events`, `nodes`, `namespaces`, `persistentvolumes`, `persistentvolumeclaims`, `serviceaccounts` などの `get`, `list`, `watch`
+- `apps`, `batch`, `networking.k8s.io`, `storage.k8s.io`, `apiextensions.k8s.io`, `argoproj.io`, `monitoring.coreos.com`, `external-secrets.io`, `projectcalico.org`, `longhorn.io`, `pingcap.com` などの `get`, `list`, `watch`
+
+明示的に許可しない操作:
+
+- core `secrets` の `get`, `list`, `watch`
+- `create`, `update`, `patch`, `delete` などの write 系 verbs
+- `pods/log`, `pods/exec`, `pods/portforward` などの pod subresource
+- `tokenreviews`, `subjectaccessreviews` など、通常 `create` を必要とする認証・認可レビュー系操作
+
+## 検証
+
+2026-07-03 の conflict 解消 run では、前回の BOXP-37 差分を最新 `origin/main` に載せ直し、追加済みの `task-board-runner` sidecar にも同じ kubeconfig / token mount を適用した。
+この Task Board run の実行環境には `kubectl` が PATH 上になかったため、前回 run で取得済みの `/tmp/kubectl-v1.36.1` を使って manifest 検証を行った。
+
+実行済み:
+
+```bash
+/tmp/kubectl-v1.36.1 version --client=true --output=yaml
+/tmp/kubectl-v1.36.1 kustomize argoproj/codex-workspace >/tmp/boxp-37-kustomize.yaml
+python3 - <<'PY'
+from pathlib import Path
+text = Path('argoproj/codex-workspace/rbac.yaml').read_text().splitlines()
+core_resources = []
+in_core_resources = False
+verbs_lines = []
+for line in text:
+    stripped = line.strip()
+    if stripped == 'resources:':
+        in_core_resources = True
+        continue
+    if in_core_resources:
+        if stripped.startswith('- '):
+            core_resources.append(stripped[2:])
+            continue
+        if stripped.startswith('verbs:'):
+            verbs_lines.append(stripped)
+            in_core_resources = False
+            continue
+    if stripped.startswith('verbs:'):
+        verbs_lines.append(stripped)
+if 'secrets' in core_resources:
+    raise SystemExit('core resources include secrets')
+for verbs in verbs_lines:
+    if verbs != 'verbs: ["get", "list", "watch"]':
+        raise SystemExit(f'unexpected verbs line: {verbs}')
+print('rbac check ok: core resources exclude secrets; all rules are get/list/watch only')
+PY
+```
+
+結果:
+
+- `kubectl` client は `v1.36.1`
+- bundled kustomize は `v5.8.1`
+- `kubectl kustomize argoproj/codex-workspace` は成功し、781 lines の manifest を生成
+- RBAC 静的確認で core `secrets` は含まれず、全 rule の verb は `get`, `list`, `watch` のみ
+
+デプロイ後に workspace Pod 内で確認するコマンド:
+
+```bash
+kubectl version --client=true --output=yaml
+kubectl kustomize --help
+kubectl get nodes
+kubectl get namespaces
+kubectl get pods -A
+kubectl get deploy -A
+kubectl get services -A
+kubectl get configmaps -A
+kubectl get events -A
+kubectl get crd
+kubectl auth can-i get secrets -A
+kubectl auth can-i create pod -A
+kubectl auth can-i patch deployment -A
+```
+
+期待値:
+
+- read 系の代表コマンドは成功する
+- `kubectl auth can-i get secrets -A` は `no`
+- `kubectl auth can-i create pod -A` は `no`
+- `kubectl auth can-i patch deployment -A` は `no`
+
+## 制限事項
+
+- この run から対象 cluster への kubeconfig がないため、実 cluster に対する `kubectl auth can-i` と read 操作は未実施。
+- `kubectl apply --dry-run=client --validate=false -f /tmp/boxp-37-kustomize.yaml` は kubeconfig なしの discovery で `localhost:8080` に接続しようとして失敗したため、検証結果には含めない。
+- custom resource の read 権限は、リポジトリで利用している API group と主要 Kubernetes 標準 API group を列挙している。新しい CRD group を追加した場合、その group の read 権限追加が必要になる可能性がある。
+- `kubectl logs`, `exec`, `port-forward` は今回の範囲外。


### PR DESCRIPTION
## Summary

- Add a dedicated `codex-workspace` ServiceAccount and in-cluster kubeconfig for the Codex workspace deployment.
- Mount a projected short-lived ServiceAccount token and kubeconfig into `workspace`, `codex-cron-scheduler`, and the newer `task-board-runner` sidecar.
- Add a cluster-wide read-only ClusterRole that enumerates core resources without `secrets` and grants `get/list/watch` for the Kubernetes and GitOps API groups used by this repo.
- Document the plan, permission scope, validation commands, conflict resolution, and remaining deployment-time checks under `docs/project_docs/BOXP-37-codex-workspace-kubectl-rbac/plan.md`.

## Validation

- Rebased the BOXP-37 change onto latest `origin/main` and resolved the `argoproj/codex-workspace/deployment.yaml` conflict with the new `task-board-runner` sidecar.
- Ran `git diff --check`.
- Ran `/tmp/kubectl-v1.36.1 version --client=true --output=yaml` and confirmed `gitVersion: v1.36.1` with bundled `kustomizeVersion: v5.8.1`.
- Ran `/tmp/kubectl-v1.36.1 kustomize argoproj/codex-workspace >/tmp/boxp-37-kustomize.yaml` successfully; generated manifest is 781 lines.
- Ran a static RBAC check confirming core `secrets` is not listed and all ClusterRole rules use only `get/list/watch`.

## Notes

This run does not have kubeconfig access to the target cluster, so the live `kubectl auth can-i` checks and representative read commands must be run after Argo CD applies the manifests. Expected checks are documented in the plan file, including `kubectl auth can-i get secrets -A` and representative write checks returning `no`.

Current PR checks were pending immediately after the force-push when this run finished.