### PR TITLE
[codex] GitOps manage Grafana Discord alerts

### DIFF
--- a/argoproj/prometheus-operator/grafana-alerting.yaml
+++ b/argoproj/prometheus-operator/grafana-alerting.yaml
@@ -1,0 +1,412 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+data:
+  contact-points.yaml: |
+    apiVersion: 1
+    contactPoints:
+      - orgId: 1
+        name: boxlab alert
+        receivers:
+          - uid: de936r1ia7jepd
+            type: discord
+            settings:
+              url: $GRAFANA_DISCORD_WEBHOOK_BOXLAB_ALERT
+              use_discord_username: false
+            disableResolveMessage: false
+      - orgId: 1
+        name: onitiku server
+        receivers:
+          - uid: de96123xro5c0c
+            type: discord
+            settings:
+              message: '{{ template "default.title" . }}'
+              url: $GRAFANA_DISCORD_WEBHOOK_ONITIKU_SERVER
+              use_discord_username: false
+            disableResolveMessage: false
+  notification-policies.yaml: |
+    apiVersion: 1
+    policies:
+      - orgId: 1
+        receiver: boxlab alert
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: Hito Hub Prod
+        folder: ""
+        interval: 1m
+        rules:
+          - uid: ee8z1xs4qz8jkf
+            title: hitohub-frontend state running count
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 21600
+                  to: 0
+                datasourceUid: P1809F7CD0C75ACF3
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: P1809F7CD0C75ACF3
+                  disableTextWrap: false
+                  editorMode: builder
+                  expr: kube_deployment_status_replicas_ready{deployment="hitohub-frontend", namespace="prod-hitohub"}
+                  fullMetaSearch: false
+                  includeNullMetadata: true
+                  instant: false
+                  interval: ""
+                  intervalMs: 15000
+                  legendFormat: '{{deployment}}'
+                  maxDataPoints: 43200
+                  range: true
+                  refId: A
+                  useBackend: false
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 1
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: ae8ywexag2rk0d
+            panelId: 3
+            noDataState: NoData
+            execErrState: Error
+            for: 1m
+            annotations:
+              __dashboardUid__: ae8ywexag2rk0d
+              __panelId__: "3"
+            isPaused: false
+            notification_settings:
+              receiver: boxlab alert
+          - uid: de9c2qjlxwge8e
+            title: hitohub-backend state running count
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 21600
+                  to: 0
+                datasourceUid: P1809F7CD0C75ACF3
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: P1809F7CD0C75ACF3
+                  disableTextWrap: false
+                  editorMode: builder
+                  expr: kube_deployment_status_replicas_ready{deployment="hitohub-back-end", namespace="prod-hitohub"}
+                  fullMetaSearch: false
+                  includeNullMetadata: true
+                  instant: false
+                  interval: ""
+                  intervalMs: 15000
+                  legendFormat: '{{deployment}}'
+                  maxDataPoints: 43200
+                  range: true
+                  refId: A
+                  useBackend: false
+              - refId: B
+                relativeTimeRange:
+                  from: 21600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                relativeTimeRange:
+                  from: 21600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 1
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: ae8ywexag2rk0d
+            panelId: 4
+            noDataState: NoData
+            execErrState: Error
+            for: 1m
+            annotations:
+              __dashboardUid__: ae8ywexag2rk0d
+              __panelId__: "4"
+            isPaused: false
+            notification_settings:
+              receiver: boxlab alert
+      - orgId: 1
+        name: ark-asa
+        folder: ""
+        interval: 1m
+        rules:
+          - uid: fenkaqm8slj40d
+            title: ark asa server restarts count
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 21600
+                  to: 0
+                datasourceUid: P1809F7CD0C75ACF3
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: P1809F7CD0C75ACF3
+                  disableTextWrap: false
+                  editorMode: builder
+                  expr: delta(kube_pod_container_status_restarts_total{container="ark-server"}[1m])
+                  fullMetaSearch: false
+                  includeNullMetadata: true
+                  instant: false
+                  interval: ""
+                  intervalMs: 15000
+                  legendFormat: '{{container}}'
+                  maxDataPoints: 43200
+                  range: true
+                  refId: A
+                  useBackend: false
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: eenkaee7v0tfkf
+            panelId: 1
+            noDataState: NoData
+            execErrState: Error
+            for: 1m
+            annotations:
+              __dashboardUid__: eenkaee7v0tfkf
+              __panelId__: "1"
+              summary: ark asa serverが再起動されました、しばらく接続できない可能性があります
+            isPaused: false
+            notification_settings:
+              receiver: onitiku server
+      - orgId: 1
+        name: onitiku-palserver
+        folder: ""
+        interval: 1m
+        rules:
+          - uid: be92yxv4y2mf4b
+            title: onitiku palworldが稼働していません
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 21600
+                  to: 0
+                datasourceUid: P1809F7CD0C75ACF3
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: P1809F7CD0C75ACF3
+                  disableTextWrap: false
+                  editorMode: builder
+                  expr: kube_deployment_status_replicas_available{deployment="palserver"}
+                  fullMetaSearch: false
+                  includeNullMetadata: true
+                  instant: false
+                  interval: ""
+                  intervalMs: 15000
+                  legendFormat: '{{deployment}}'
+                  maxDataPoints: 43200
+                  range: true
+                  refId: A
+                  useBackend: false
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 1
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: be92yab5yh69sc
+            panelId: 1
+            noDataState: NoData
+            execErrState: Error
+            for: 1m
+            annotations:
+              __dashboardUid__: be92yab5yh69sc
+              __panelId__: "1"
+              description: <@boxp> 対応してください
+              summary: onitiku palworldが稼働していません
+            isPaused: false
+            notification_settings:
+              receiver: onitiku server

--- a/argoproj/prometheus-operator/grafana-alerting.yaml
+++ b/argoproj/prometheus-operator/grafana-alerting.yaml
@@ -10,6 +10,9 @@ metadata:
 data:
   contact-points.yaml: |
     apiVersion: 1
+    deleteContactPoints:
+      - orgId: 1
+        uid: de96123xro5c0c
     contactPoints:
       - orgId: 1
         name: boxlab alert
@@ -20,16 +23,6 @@ data:
               url: $GRAFANA_DISCORD_WEBHOOK_BOXLAB_ALERT
               use_discord_username: false
             disableResolveMessage: false
-      - orgId: 1
-        name: onitiku server
-        receivers:
-          - uid: de96123xro5c0c
-            type: discord
-            settings:
-              message: '{{ template "default.title" . }}'
-              url: $GRAFANA_DISCORD_WEBHOOK_ONITIKU_SERVER
-              use_discord_username: false
-            disableResolveMessage: false
   notification-policies.yaml: |
     apiVersion: 1
     policies:
@@ -37,6 +30,11 @@ data:
         receiver: boxlab alert
   rules.yaml: |
     apiVersion: 1
+    deleteRules:
+      - orgId: 1
+        uid: fenkaqm8slj40d
+      - orgId: 1
+        uid: be92yxv4y2mf4b
     groups:
       - orgId: 1
         name: Hito Hub Prod
@@ -223,190 +221,3 @@ data:
             isPaused: false
             notification_settings:
               receiver: boxlab alert
-      - orgId: 1
-        name: ark-asa
-        folder: ""
-        interval: 1m
-        rules:
-          - uid: fenkaqm8slj40d
-            title: ark asa server restarts count
-            condition: C
-            data:
-              - refId: A
-                relativeTimeRange:
-                  from: 21600
-                  to: 0
-                datasourceUid: P1809F7CD0C75ACF3
-                model:
-                  datasource:
-                    type: prometheus
-                    uid: P1809F7CD0C75ACF3
-                  disableTextWrap: false
-                  editorMode: builder
-                  expr: delta(kube_pod_container_status_restarts_total{container="ark-server"}[1m])
-                  fullMetaSearch: false
-                  includeNullMetadata: true
-                  instant: false
-                  interval: ""
-                  intervalMs: 15000
-                  legendFormat: '{{container}}'
-                  maxDataPoints: 43200
-                  range: true
-                  refId: A
-                  useBackend: false
-              - refId: B
-                datasourceUid: __expr__
-                model:
-                  conditions:
-                    - evaluator:
-                        params: []
-                        type: gt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                          - B
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                  datasource:
-                    type: __expr__
-                    uid: __expr__
-                  expression: A
-                  intervalMs: 1000
-                  maxDataPoints: 43200
-                  reducer: last
-                  refId: B
-                  type: reduce
-              - refId: C
-                datasourceUid: __expr__
-                model:
-                  conditions:
-                    - evaluator:
-                        params:
-                          - 0
-                        type: gt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                          - C
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                  datasource:
-                    type: __expr__
-                    uid: __expr__
-                  expression: B
-                  intervalMs: 1000
-                  maxDataPoints: 43200
-                  refId: C
-                  type: threshold
-            dashboardUid: eenkaee7v0tfkf
-            panelId: 1
-            noDataState: NoData
-            execErrState: Error
-            for: 1m
-            annotations:
-              __dashboardUid__: eenkaee7v0tfkf
-              __panelId__: "1"
-              summary: ark asa serverが再起動されました、しばらく接続できない可能性があります
-            isPaused: false
-            notification_settings:
-              receiver: onitiku server
-      - orgId: 1
-        name: onitiku-palserver
-        folder: ""
-        interval: 1m
-        rules:
-          - uid: be92yxv4y2mf4b
-            title: onitiku palworldが稼働していません
-            condition: C
-            data:
-              - refId: A
-                relativeTimeRange:
-                  from: 21600
-                  to: 0
-                datasourceUid: P1809F7CD0C75ACF3
-                model:
-                  datasource:
-                    type: prometheus
-                    uid: P1809F7CD0C75ACF3
-                  disableTextWrap: false
-                  editorMode: builder
-                  expr: kube_deployment_status_replicas_available{deployment="palserver"}
-                  fullMetaSearch: false
-                  includeNullMetadata: true
-                  instant: false
-                  interval: ""
-                  intervalMs: 15000
-                  legendFormat: '{{deployment}}'
-                  maxDataPoints: 43200
-                  range: true
-                  refId: A
-                  useBackend: false
-              - refId: B
-                datasourceUid: __expr__
-                model:
-                  conditions:
-                    - evaluator:
-                        params: []
-                        type: gt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                          - B
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                  datasource:
-                    type: __expr__
-                    uid: __expr__
-                  expression: A
-                  intervalMs: 1000
-                  maxDataPoints: 43200
-                  reducer: last
-                  refId: B
-                  type: reduce
-              - refId: C
-                datasourceUid: __expr__
-                model:
-                  conditions:
-                    - evaluator:
-                        params:
-                          - 1
-                        type: lt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                          - C
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                  datasource:
-                    type: __expr__
-                    uid: __expr__
-                  expression: B
-                  intervalMs: 1000
-                  maxDataPoints: 43200
-                  refId: C
-                  type: threshold
-            dashboardUid: be92yab5yh69sc
-            panelId: 1
-            noDataState: NoData
-            execErrState: Error
-            for: 1m
-            annotations:
-              __dashboardUid__: be92yab5yh69sc
-              __panelId__: "1"
-              description: <@boxp> 対応してください
-              summary: onitiku palworldが稼働していません
-            isPaused: false
-            notification_settings:
-              receiver: onitiku server

--- a/argoproj/prometheus-operator/grafana-discord-webhooks.yaml
+++ b/argoproj/prometheus-operator/grafana-discord-webhooks.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-discord-webhooks
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: grafana-discord-webhooks
+    creationPolicy: Owner
+  data:
+    - secretKey: boxlab-alert-webhook-url
+      remoteRef:
+        key: /lolice/grafana/discord-webhook-boxlab-alert
+    - secretKey: onitiku-server-webhook-url
+      remoteRef:
+        key: /lolice/grafana/discord-webhook-onitiku-server

--- a/argoproj/prometheus-operator/grafana-discord-webhooks.yaml
+++ b/argoproj/prometheus-operator/grafana-discord-webhooks.yaml
@@ -15,6 +15,3 @@ spec:
     - secretKey: boxlab-alert-webhook-url
       remoteRef:
         key: /lolice/grafana/discord-webhook-boxlab-alert
-    - secretKey: onitiku-server-webhook-url
-      remoteRef:
-        key: /lolice/grafana/discord-webhook-onitiku-server

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - grafana-lb.yaml
 - external-secret.yaml
 - cloudflared-deployment.yaml
+- grafana-alerting.yaml
+- grafana-discord-webhooks.yaml
 - grafana-pvc.yaml
 - scrape-config.yaml
 - control-plane-node-rules.yaml
@@ -32,3 +34,10 @@ patchesJson6902:
       name: grafana
       namespace: monitoring
   path: patches/grafana-remove-empty-dir.yaml
+- target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: grafana
+      namespace: monitoring
+  path: patches/grafana-add-alerting-volume.yaml

--- a/argoproj/prometheus-operator/overlays/grafana.yaml
+++ b/argoproj/prometheus-operator/overlays/grafana.yaml
@@ -5,9 +5,24 @@ metadata:
   namespace: monitoring
 spec:
   template:
+    metadata:
+      annotations:
+        configmap.reloader.stakater.com/reload: grafana-alerting
+        secret.reloader.stakater.com/reload: grafana-discord-webhooks
     spec:
       containers:
         - name: grafana
+          env:
+            - name: GRAFANA_DISCORD_WEBHOOK_BOXLAB_ALERT
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-discord-webhooks
+                  key: boxlab-alert-webhook-url
+            - name: GRAFANA_DISCORD_WEBHOOK_ONITIKU_SERVER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-discord-webhooks
+                  key: onitiku-server-webhook-url
           resources:
             requests:
               cpu: 500m
@@ -15,6 +30,10 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - mountPath: /etc/grafana/provisioning/alerting
+              name: grafana-alerting
+              readOnly: true
       volumes:
         - name: grafana-storage
           persistentVolumeClaim:

--- a/argoproj/prometheus-operator/overlays/grafana.yaml
+++ b/argoproj/prometheus-operator/overlays/grafana.yaml
@@ -18,11 +18,6 @@ spec:
                 secretKeyRef:
                   name: grafana-discord-webhooks
                   key: boxlab-alert-webhook-url
-            - name: GRAFANA_DISCORD_WEBHOOK_ONITIKU_SERVER
-              valueFrom:
-                secretKeyRef:
-                  name: grafana-discord-webhooks
-                  key: onitiku-server-webhook-url
           resources:
             requests:
               cpu: 500m

--- a/argoproj/prometheus-operator/patches/grafana-add-alerting-volume.yaml
+++ b/argoproj/prometheus-operator/patches/grafana-add-alerting-volume.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: grafana-alerting
+    configMap:
+      name: grafana-alerting

--- a/docs/project_docs/BOXP-40-grafana-alert-notifications/plan.md
+++ b/docs/project_docs/BOXP-40-grafana-alert-notifications/plan.md
@@ -1,0 +1,48 @@
+# BOXP-40 Grafana Alert Notifications
+
+## 方針
+
+SMTP は現環境では使わないため、email 通知は復旧対象外にする。Grafana Alerting の Discord 通知だけを GitOps 管理に移し、既存 UI 設定に依存して pause されたままにならない状態を作る。
+
+## 実態確認
+
+- 2026-07-04 01:31 UTC: Grafana API は到達可能。version 13.0.2 / database ok。
+- 2026-07-04 01:31 UTC: Grafana-managed alert rule 4 件はすべて `isPaused: true`。Prometheus-compatible rules API でも `lastEvaluation: 0001-01-01T00:00:00Z` で、通知以前に評価が止まっていた。
+- 2026-07-04 01:31 UTC: Discord contact point は `boxlab alert` と `onitiku server` の 2 件。email contact point も存在するが、SMTP は使わないため今回の GitOps 対象外。
+- 2026-07-04 01:31 UTC: default notification policy は `boxlab alert`。rule-level receiver は hitohub 2 件が `boxlab alert`、ark/palserver が `onitiku server`。
+- 2026-07-04 01:32 UTC: active silence と mute timing は 0 件。
+- 2026-07-04 01:32 UTC: `monitoring/grafana` NetworkPolicy は egress 全許可。Discord webhook への外向き通信を repo 上で明示的に止める設定は見つからなかった。
+- 2026-07-04 01:32 UTC: 現在の Grafana service account token では contact point test API と alert rule write API が 403。Secret 参照と Pod log 参照も Kubernetes RBAC で不可。
+
+## 変更内容
+
+- `argoproj/prometheus-operator/grafana-alerting.yaml`
+  - Discord contact point 2 件を provisioning 化する。
+  - default notification policy を `boxlab alert` として provisioning 化する。
+  - 既存 alert rule 4 件を provisioning 化し、`isPaused: false` にする。
+  - alert rule ごとの `notification_settings.receiver` は現行実態に合わせる。
+- `argoproj/prometheus-operator/grafana-discord-webhooks.yaml`
+  - Discord webhook URL を ExternalSecret で `Secret/grafana-discord-webhooks` に同期する。
+  - SSM Parameter Store に次の SecureString が必要:
+    - `/lolice/grafana/discord-webhook-boxlab-alert`
+    - `/lolice/grafana/discord-webhook-onitiku-server`
+- `argoproj/prometheus-operator/overlays/grafana.yaml`
+  - Grafana に Discord webhook URL を環境変数として注入する。
+  - `/etc/grafana/provisioning/alerting` に provisioning ConfigMap を mount する。
+  - Reloader annotation を付与し、ConfigMap / Secret 更新時に Grafana Pod を再起動させる。
+- Grafana 公式 docs では既存の alerting resource を file provisioning に import すると競合する場合があるため、初回適用時に Grafana Pod log で provisioning conflict が出た場合は、同 UID の UI 管理 rule/contact point を削除してから再 sync する。
+
+## 適用後の確認手順
+
+1. SSM Parameter Store に Discord webhook URL 2 件を登録する。値はチケット、PR、ログに出さない。
+2. Argo CD で `prometheus-operator` Application を sync する。
+3. `ExternalSecret/grafana-discord-webhooks` が Ready になり、`Secret/grafana-discord-webhooks` が作成されたことを確認する。
+4. Grafana Pod が再起動し、provisioning エラーなく起動したことを確認する。
+5. Grafana API または UI で alert rule 4 件が `isPaused: false` になり、`lastEvaluation` が現在時刻に更新されることを確認する。
+6. Discord contact point test または安全な一時テスト alert で、`boxlab alert` と `onitiku server` の両方の Discord 受信時刻を記録する。
+
+## 残課題
+
+- この Codex workspace の権限では Discord test notification と Grafana rule write が 403 のため、実送信確認は未完了。
+- SSM Parameter Store への Discord webhook URL 登録が必要。未登録のまま Argo CD sync すると Grafana Pod は Secret 参照待ちになる。
+- 初回適用時に既存 UI 管理リソースとの provisioning conflict が出る可能性がある。

--- a/docs/project_docs/BOXP-40-grafana-alert-notifications/plan.md
+++ b/docs/project_docs/BOXP-40-grafana-alert-notifications/plan.md
@@ -2,7 +2,7 @@
 
 ## 方針
 
-SMTP は現環境では使わないため、email 通知は復旧対象外にする。Grafana Alerting の Discord 通知だけを GitOps 管理に移し、既存 UI 設定に依存して pause されたままにならない状態を作る。
+SMTP は現環境では使わないため、email 通知は復旧対象外にする。Grafana Alerting の Discord 通知だけを GitOps 管理に移し、既存 UI 設定に依存して pause されたままにならない状態を作る。`onitiku server` 向け alert は稼働終了済みのため削除し、`boxlab alert` 宛ての Hito Hub alert だけを残す。
 
 ## 実態確認
 
@@ -13,19 +13,20 @@ SMTP は現環境では使わないため、email 通知は復旧対象外にす
 - 2026-07-04 01:32 UTC: active silence と mute timing は 0 件。
 - 2026-07-04 01:32 UTC: `monitoring/grafana` NetworkPolicy は egress 全許可。Discord webhook への外向き通信を repo 上で明示的に止める設定は見つからなかった。
 - 2026-07-04 01:32 UTC: 現在の Grafana service account token では contact point test API と alert rule write API が 403。Secret 参照と Pod log 参照も Kubernetes RBAC で不可。
+- 2026-07-04 03:35 UTC: 追加要望により、稼働終了済みの `onitiku server` 向け alert は削除対象に変更した。
 
 ## 変更内容
 
 - `argoproj/prometheus-operator/grafana-alerting.yaml`
-  - Discord contact point 2 件を provisioning 化する。
+  - `boxlab alert` Discord contact point を provisioning 化する。
+  - `onitiku server` Discord contact point は `deleteContactPoints` で削除する。
   - default notification policy を `boxlab alert` として provisioning 化する。
-  - 既存 alert rule 4 件を provisioning 化し、`isPaused: false` にする。
-  - alert rule ごとの `notification_settings.receiver` は現行実態に合わせる。
+  - Hito Hub alert rule 2 件を provisioning 化し、`isPaused: false` にする。
+  - `onitiku server` 向けだった ark / palserver alert rule 2 件は `deleteRules` で削除する。
 - `argoproj/prometheus-operator/grafana-discord-webhooks.yaml`
   - Discord webhook URL を ExternalSecret で `Secret/grafana-discord-webhooks` に同期する。
   - SSM Parameter Store に次の SecureString が必要:
     - `/lolice/grafana/discord-webhook-boxlab-alert`
-    - `/lolice/grafana/discord-webhook-onitiku-server`
 - `argoproj/prometheus-operator/overlays/grafana.yaml`
   - Grafana に Discord webhook URL を環境変数として注入する。
   - `/etc/grafana/provisioning/alerting` に provisioning ConfigMap を mount する。
@@ -34,15 +35,16 @@ SMTP は現環境では使わないため、email 通知は復旧対象外にす
 
 ## 適用後の確認手順
 
-1. SSM Parameter Store に Discord webhook URL 2 件を登録する。値はチケット、PR、ログに出さない。
+1. SSM Parameter Store に `boxlab alert` の Discord webhook URL を登録する。値はチケット、PR、ログに出さない。
 2. Argo CD で `prometheus-operator` Application を sync する。
 3. `ExternalSecret/grafana-discord-webhooks` が Ready になり、`Secret/grafana-discord-webhooks` が作成されたことを確認する。
 4. Grafana Pod が再起動し、provisioning エラーなく起動したことを確認する。
-5. Grafana API または UI で alert rule 4 件が `isPaused: false` になり、`lastEvaluation` が現在時刻に更新されることを確認する。
-6. Discord contact point test または安全な一時テスト alert で、`boxlab alert` と `onitiku server` の両方の Discord 受信時刻を記録する。
+5. Grafana API または UI で Hito Hub alert rule 2 件が `isPaused: false` になり、`lastEvaluation` が現在時刻に更新されることを確認する。
+6. Grafana API または UI で `onitiku server` contact point と ark / palserver alert rule 2 件が削除されていることを確認する。
+7. Discord contact point test または安全な一時テスト alert で、`boxlab alert` の Discord 受信時刻を記録する。
 
 ## 残課題
 
 - この Codex workspace の権限では Discord test notification と Grafana rule write が 403 のため、実送信確認は未完了。
-- SSM Parameter Store への Discord webhook URL 登録が必要。未登録のまま Argo CD sync すると Grafana Pod は Secret 参照待ちになる。
+- SSM Parameter Store への `boxlab alert` Discord webhook URL 登録が必要。未登録のまま Argo CD sync すると Grafana Pod は Secret 参照待ちになる。
 - 初回適用時に既存 UI 管理リソースとの provisioning conflict が出る可能性がある。


### PR DESCRIPTION
## Summary

- Provision Grafana Discord alerting from Git for the remaining `boxlab alert` route.
- Set the two Hito Hub Grafana-managed alert rules to `isPaused: false` so evaluation resumes after Argo CD sync / Grafana restart.
- Remove the inactive `onitiku server` Discord contact point and its ark / palserver alert rules via Grafana alerting file provisioning delete declarations.
- Add an ExternalSecret for the remaining Discord webhook URL and inject it into Grafana as an environment variable.
- Mount `/etc/grafana/provisioning/alerting` and add Reloader annotations so alerting config / webhook secret changes restart Grafana.
- Record investigation notes and apply/verification steps in `docs/project_docs/BOXP-40-grafana-alert-notifications/plan.md`.

## Context

Current cluster investigation found Grafana reachable, but all four Grafana-managed alert rules were paused and had never evaluated (`lastEvaluation: 0001-01-01T00:00:00Z`). Active silences and mute timings were empty. The `monitoring/grafana` NetworkPolicy allows egress, so the immediate blocker is that alert evaluation is disabled before Discord delivery can happen.

SMTP/email is intentionally out of scope per the updated task direction. `onitiku server` alerts are also out of scope now because that service is no longer running; this PR removes that contact point and the two rules that were routed to it.

## Required Before Sync

Create this SSM Parameter Store value as SecureString. Do not put the actual webhook URL in GitHub, tickets, or logs.

- `/lolice/grafana/discord-webhook-boxlab-alert`

If this parameter is missing, `Secret/grafana-discord-webhooks` will not be populated and the Grafana Pod can wait on the required Secret env ref.

## Validation

- `kustomize build argoproj/prometheus-operator >/tmp/boxp40-prometheus-operator.yaml`
- `git diff --check`
- `kubectl create --dry-run=client --validate=false -f /tmp/boxp40-prometheus-operator.yaml`

`kustomize build` reports the repo's existing `patchesJson6902` / `patchesStrategicMerge` deprecation warnings only.

## Follow-up Verification After Merge/Sync

- Confirm `ExternalSecret/grafana-discord-webhooks` is Ready and `Secret/grafana-discord-webhooks` exists with the `boxlab-alert-webhook-url` key.
- Confirm Grafana starts without alerting provisioning errors.
- Confirm the two Hito Hub alert rules are `isPaused: false` and `lastEvaluation` updates.
- Confirm the `onitiku server` contact point and ark / palserver alert rules are gone.
- Send a Grafana test notification or a safe temporary test alert to `boxlab alert` and record the received timestamp.
- If Grafana reports a provisioning conflict with existing UI-managed resources, delete the matching UI-managed rule/contact point and re-sync so file provisioning becomes the source of truth.
