### PR TITLE
BOXP-34 rollback Gemma4 vision config

### DIFF
--- a/argoproj/codex-workspace/configmap.yaml
+++ b/argoproj/codex-workspace/configmap.yaml
@@ -39,7 +39,7 @@ data:
               "id": "gemma4-26b",
               "name": "Gemma4 26B local",
               "reasoning": false,
-              "input": ["text", "image"],
+              "input": ["text"],
               "contextWindow": 262144,
               "maxTokens": 4096,
               "cost": {

--- a/argoproj/local-llm/models-config.yaml
+++ b/argoproj/local-llm/models-config.yaml
@@ -8,7 +8,6 @@ data:
 
     [gemma4-26b]
     model = /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
-    mmproj = /models/mmproj-Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-BF16.gguf
     ctx-size = 262144
     batch-size = 2048
     ubatch-size = 1024

--- a/docs/project_docs/BOXP-34-gemma4-vision/plan.md
+++ b/docs/project_docs/BOXP-34-gemma4-vision/plan.md
@@ -111,3 +111,18 @@ EOF
 - `argoproj/local-llm/models-config.yaml` の `mmproj = ...` 行を削除する。
 - `argoproj/codex-workspace/configmap.yaml` の `gemma4-26b.input` を `["text"]` に戻す。
 - 追加した `mmproj` ファイルはホスト上に残置してよい。ディスク容量を戻す必要がある場合のみ `/var/lib/local-llm/models/mmproj-Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-BF16.gguf` を削除する。
+
+## 2026-07-04 Rollback
+
+After the vision rollout, `gemma4-26b` became unavailable from pi agent. Direct health and model list checks against `llama-server.local-llm.svc.cluster.local:8080` still worked, and `ornith-35b` returned `OK` through the same router, but `gemma4-26b` failed with:
+
+```text
+500: {"code":500,"message":"model name=gemma4-26b failed to load","type":"server_error"}
+```
+
+`/v1/models` reported `gemma4-26b` as `failed: true` with `exit_code: 1` after the `mmproj` preset was added. Roll back only the vision-specific parts for service recovery:
+
+- remove `mmproj = /models/mmproj-Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-BF16.gguf`
+- change pi agent `gemma4-26b.input` back from `["text", "image"]` to `["text"]`
+
+Keep the projector file on the host if it exists. Reintroduce vision under a separate model ID, for example `gemma4-26b-vision`, only after validating model/projector compatibility and load behavior on `golyat-4`.


### PR DESCRIPTION
## Summary
- remove the Gemma4 `mmproj` preset that makes `gemma4-26b` fail to load
- change pi agent metadata for `gemma4-26b` back to text-only input
- document the 2026-07-04 rollback findings in `docs/project_docs/BOXP-34-gemma4-vision/plan.md`

## Observed failure
- `llama-server.local-llm.svc.cluster.local:8080/health` returned OK
- `/v1/models` showed `gemma4-26b` as failed with `exit_code: 1`
- pi agent returned `500: model name=gemma4-26b failed to load`
- `ornith-35b` returned `OK` through the same router, so the issue is isolated to Gemma4 vision loading rather than connectivity

## Validation
- `git diff --check`
- `kubectl kustomize argoproj/local-llm`
- `kubectl kustomize argoproj/codex-workspace`
- `codex review --uncommitted`

Refs: BOXP-34