### PR TITLE
[codex] Keep Hermes SOUL.md on PVC only

### DIFF
--- a/argoproj/hermes-agent/configmap.yaml
+++ b/argoproj/hermes-agent/configmap.yaml
@@ -21,7 +21,3 @@ data:
       hard_stop_after:
         exact_failure: 5
         idempotent_no_progress: 5
-
-  SOUL.md: |
-    You are Hermes Agent running on the lolice cluster.
-    Use the local gemma4-26b-vision backend for model inference.

--- a/argoproj/hermes-agent/deployment.yaml
+++ b/argoproj/hermes-agent/deployment.yaml
@@ -40,11 +40,6 @@ spec:
                 chown 1000:10000 /opt/data/config.yaml
                 chmod 0664 /opt/data/config.yaml
               fi
-              if [ ! -f /opt/data/SOUL.md ]; then
-                cp /bootstrap/SOUL.md /opt/data/SOUL.md
-                chown 1000:10000 /opt/data/SOUL.md
-                chmod 0664 /opt/data/SOUL.md
-              fi
               chown 1000:10000 \
                 /opt/data \
                 /opt/data/Documents \


### PR DESCRIPTION
## 概要 (BOXP-52)

Hermes Agent の `SOUL.md` を GitOps-managed ConfigMap ではなく、既存の `hermes-agent-data` PVC 上の `/opt/data/SOUL.md` を正として扱うようにします。

## 内容

- `hermes-agent-config` ConfigMap から `SOUL.md` を削除
- initContainer の `/bootstrap/SOUL.md` seed 処理を削除
- `config.yaml` の初回 bootstrap は維持

## 反映について

既存環境では PVC 上の `/opt/data/SOUL.md` を直接更新済みです。内容はコハコ (Kohako.EXE) persona で、checksum は `9220c33d23dd09faa67bbb55b63f0d57aa30d0c4d8e5bd21a78eb27f73af1419` です。

この PR の merge 後は、ConfigMap 変更で `SOUL.md` が上書き・seed されません。今後の persona 変更は PVC 上の `SOUL.md` を直接編集します。

## 検証

- `kubectl kustomize argoproj/hermes-agent`
- `kubectl kustomize argoproj`
- live PVC 上の `/opt/data/SOUL.md` がコハコ persona の内容であることを確認
