### PR TITLE
fix(hermes-agent): allow dashboard tunnel origin

### DIFF
--- a/argoproj/hermes-agent/deployment.yaml
+++ b/argoproj/hermes-agent/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             - name: HERMES_DASHBOARD
               value: "true"
             - name: HERMES_DASHBOARD_HOST
-              value: "127.0.0.1"
+              value: "0.0.0.0"
             - name: HERMES_DASHBOARD_PORT
               value: "9119"
             - name: HERMES_DASHBOARD_PUBLIC_URL


### PR DESCRIPTION
## Summary
- bind Hermes dashboard to 0.0.0.0 so Cloudflare Tunnel WebSocket Origin checks pass

## Validation
- kubectl kustomize argoproj/hermes-agent
- kubectl kustomize argoproj