### PR TITLE
fix(hermes-agent): match calico network policy defaults

### DIFF
--- a/argoproj/hermes-agent/networkpolicy.yaml
+++ b/argoproj/hermes-agent/networkpolicy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hermes-agent-network-policy
   namespace: hermes-agent
 spec:
+  tier: default
   selector: app == 'hermes-agent'
   types:
     - Ingress
@@ -12,6 +13,7 @@ spec:
   egress:
     - action: Allow
       protocol: UDP
+      source: {}
       destination:
         selector: k8s-app == 'kube-dns'
         namespaceSelector: kubernetes.io/metadata.name == 'kube-system'
@@ -19,6 +21,7 @@ spec:
           - 53
     - action: Allow
       protocol: TCP
+      source: {}
       destination:
         selector: k8s-app == 'kube-dns'
         namespaceSelector: kubernetes.io/metadata.name == 'kube-system'
@@ -26,6 +29,7 @@ spec:
           - 53
     - action: Allow
       protocol: TCP
+      source: {}
       destination:
         selector: app == 'llama-server'
         namespaceSelector: kubernetes.io/metadata.name == 'local-llm'
@@ -33,6 +37,7 @@ spec:
           - 8080
     - action: Allow
       protocol: TCP
+      source: {}
       destination:
         ports:
           - 22
@@ -41,6 +46,7 @@ spec:
           - 7844
     - action: Allow
       protocol: UDP
+      source: {}
       destination:
         ports:
           - 2408


### PR DESCRIPTION
## Summary
- declare Calico defaulted NetworkPolicy fields so Argo CD diff does not drift

## Validation
- kubectl kustomize argoproj/hermes-agent
- kubectl kustomize argoproj