### PR TITLE
revert(hermes-agent): restore loopback dashboard bind

### DIFF
--- a/argoproj/hermes-agent/deployment.yaml
+++ b/argoproj/hermes-agent/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             - name: HERMES_DASHBOARD
               value: "true"
             - name: HERMES_DASHBOARD_HOST
-              value: "0.0.0.0"
+              value: "127.0.0.1"
             - name: HERMES_DASHBOARD_PORT
               value: "9119"
             - name: HERMES_DASHBOARD_PUBLIC_URL


### PR DESCRIPTION
## Summary
- revert dashboard bind host to 127.0.0.1 because Hermes refuses unauthenticated 0.0.0.0 dashboard binds, causing Cloudflare 502
- keep Calico drift fix from #701

## Validation
- kubectl kustomize argoproj/hermes-agent
- kubectl kustomize argoproj