### PR TITLE
fix(hermes-agent): omit empty calico ingress list

### DIFF
--- a/argoproj/hermes-agent/networkpolicy.yaml
+++ b/argoproj/hermes-agent/networkpolicy.yaml
@@ -9,7 +9,6 @@ spec:
   types:
     - Ingress
     - Egress
-  ingress: []
   egress:
     - action: Allow
       protocol: UDP


### PR DESCRIPTION
## Summary
- remove empty Calico NetworkPolicy ingress list because the API drops it, leaving Argo CD OutOfSync

## Validation
- kubectl kustomize argoproj/hermes-agent
- kubectl kustomize argoproj