### PR TITLE
Add Babashka to hermes agent

### DIFF
--- a/argoproj/hermes-agent/deployment.yaml
+++ b/argoproj/hermes-agent/deployment.yaml
@@ -90,6 +90,31 @@ spec:
           volumeMounts:
             - name: obsidian-headless
               mountPath: /opt/obsidian-headless
+        - name: install-babashka
+          image: docker.io/library/busybox:1.38.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              wget -O /tmp/babashka.tar.gz "https://github.com/babashka/babashka/releases/download/v${BABASHKA_VERSION}/babashka-${BABASHKA_VERSION}-linux-amd64-static.tar.gz"
+              echo "${BABASHKA_SHA256}  /tmp/babashka.tar.gz" | sha256sum -c -
+              tar -xzf /tmp/babashka.tar.gz -C /opt/hermes-tools bb
+              chmod 0755 /opt/hermes-tools/bb
+          env:
+            - name: BABASHKA_VERSION
+              value: "1.12.218"
+            - name: BABASHKA_SHA256
+              value: 7bd028cc794732ffde3da31ce4379840893c8e54f1046f92a8dfc4f4b3cddaf8
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: hermes-tools
+              mountPath: /opt/hermes-tools
       containers:
         - name: hermes-agent
           image: docker.io/nousresearch/hermes-agent:latest
@@ -128,6 +153,10 @@ spec:
               mountPath: /home/boxp
             - name: tmp
               mountPath: /tmp
+            - name: hermes-tools
+              mountPath: /usr/local/bin/bb
+              subPath: bb
+              readOnly: true
         - name: obsidian-sync
           image: docker.io/library/node:24-bookworm-slim
           imagePullPolicy: IfNotPresent
@@ -170,6 +199,8 @@ spec:
           persistentVolumeClaim:
             claimName: hermes-agent-data
         - name: obsidian-headless
+          emptyDir: {}
+        - name: hermes-tools
           emptyDir: {}
         - name: config
           configMap:


### PR DESCRIPTION
## Summary
- add a lightweight BusyBox initContainer that downloads the official Babashka static release
- verify the downloaded archive with SHA-256 before installing bb into an emptyDir
- mount only the bb binary into hermes-agent at /usr/local/bin/bb

## Checks
- kubectl kustomize argoproj/hermes-agent
- git diff --check
- codex review --uncommitted