### PR TITLE
[codex] BOXP-57 tune local LLM runtime flags

### DIFF
--- a/argoproj/local-llm/deployment.yaml
+++ b/argoproj/local-llm/deployment.yaml
@@ -52,13 +52,8 @@ spec:
             - "262144"
             - --parallel
             - "1"
-            - --cache-type-k
-            - q8_0
-            - --cache-type-v
-            - q8_0
             - -fa
-            - "on"
-            - --cpu-moe
+            - auto
             - --no-mmap
             - --jinja
             - --reasoning

--- a/docs/project_docs/BOXP-57-local-llm-evo-t1-tuning/plan.md
+++ b/docs/project_docs/BOXP-57-local-llm-evo-t1-tuning/plan.md
@@ -1,0 +1,73 @@
+# BOXP-57 local-llm EVO-T1 tuning
+
+## Goal
+
+Make the `local-llm` Gemma4 runtime safer on EVO-T1 / Arrow Lake iGPU by avoiding the known-risk SYCL combination of Flash Attention forced on with quantized KV cache, then benchmark MoE offload and thread settings before any further performance tuning.
+
+## Changes
+
+1. Remove explicit `--cache-type-k q8_0` and `--cache-type-v q8_0` from `argoproj/local-llm/deployment.yaml`.
+   - llama.cpp defaults the KV cache back to f16.
+   - This avoids the quantized-KV path reported to segfault or corrupt output on SYCL / Arrow Lake iGPU.
+2. Change `-fa on` to `-fa auto`.
+   - This lets llama.cpp choose a compatible attention path instead of forcing the problematic path.
+3. Remove `--cpu-moe`.
+   - EVO-T1's iGPU shares system memory bandwidth with the CPU, so CPU MoE offload is not expected to reduce memory pressure in the same way it does on a discrete GPU.
+   - The final decision should still be confirmed with `llama-bench` on the GPU worker.
+
+## Validation
+
+Run manifest validation:
+
+```bash
+kubectl kustomize argoproj/local-llm >/tmp/lolice-local-llm.yaml
+kubectl apply --dry-run=server -k argoproj/local-llm
+```
+
+After Argo CD sync:
+
+```bash
+kubectl -n argocd get app local-llm -o jsonpath='{.status.sync.status} {.status.health.status}{"\n"}'
+kubectl -n local-llm rollout status deploy/llama-server
+kubectl -n local-llm logs deploy/llama-server -c llama-server --tail=200
+curl -sS http://llama-server.local-llm.svc.cluster.local:8080/health
+curl -sS http://llama-server.local-llm.svc.cluster.local:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer local-llm' \
+  -d '{"model":"gemma4-26b","messages":[{"role":"user","content":"日本語で、文字化けせずに一文で挨拶して。"}],"max_tokens":64,"temperature":0}'
+```
+
+## Benchmark Plan
+
+The current `ghcr.io/boxp/arch/llama-sycl` image contains `llama-server` but not `llama-bench`, so benchmark execution needs either a bench-capable image or a temporary debug image on `golyat-4`.
+
+Baseline matrix:
+
+```bash
+llama-bench \
+  -m /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf \
+  -ngl 99 \
+  -p 512 \
+  -n 128 \
+  -t 8,12,14 \
+  -fa 0,1
+```
+
+MoE matrix:
+
+```bash
+llama-bench \
+  -m /models/Gemma4-26B-A4B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf \
+  -ngl 99 \
+  -p 512 \
+  -n 128 \
+  -t 14 \
+  --n-cpu-moe 0,16,999
+```
+
+Record pp512 and tg128 results here after running the matrix.
+
+## Notes
+
+- 2026-07-07: Live `local-llm` Deployment was running `--cache-type-k q8_0`, `--cache-type-v q8_0`, `-fa on`, and `--cpu-moe`.
+- 2026-07-07: The live container has `/opt/llama.cpp/bin/llama-server` but no `llama-bench`, so repository changes were prepared first and benchmark execution remains a follow-up deployment validation step.


### PR DESCRIPTION
## Summary

- Remove explicit q8_0 KV cache flags from the local-llm llama-server deployment so llama.cpp falls back to f16 KV cache.
- Change Flash Attention from forced `on` to `auto`.
- Remove `--cpu-moe` for the EVO-T1 shared-memory iGPU path.
- Add BOXP-57 project notes with validation commands and the remaining `llama-bench` matrix.

## Why

The current production combination of forced Flash Attention plus quantized KV cache is a known-risk path for SYCL / Arrow Lake iGPU behavior, including output corruption and crashes. EVO-T1 also shares CPU and iGPU memory bandwidth, so CPU MoE offload is unlikely to help the way it can on a discrete GPU.

## Validation

- `kubectl kustomize argoproj/local-llm >/tmp/lolice-local-llm.yaml`
- `kubectl apply --dry-run=server -k argoproj/local-llm`

## Notes

The live `ghcr.io/boxp/arch/llama-sycl` container has `llama-server` but does not include `llama-bench`, so pp512/tg128 measurements remain a follow-up using a bench-capable image or temporary debug pod.