### PR TITLE
feat: add dotfiles-sync sidecar to codex-workspace deployment

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -193,6 +193,41 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
+        - name: dotfiles-sync
+          image: ghcr.io/boxp/arch/codex-workspace:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/bash
+            - -c
+            - |
+              exec /opt/codex-workspace/dotfiles-sync.sh
+          env:
+            - name: HOME
+              value: /home/boxp
+            - name: DOTFILES_DIR
+              value: /home/boxp/ghq/github.com/boxp/dotfiles
+            - name: DOTFILES_REPO
+              value: https://github.com/boxp/dotfiles
+            - name: SYNC_INTERVAL
+              value: "300"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["SETUID", "SETGID"]
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"
+          volumeMounts:
+            - name: home
+              mountPath: /home/boxp
         - name: obsidian-task-board-draft
           image: ghcr.io/boxp/arch/codex-workspace:latest
           imagePullPolicy: Always


### PR DESCRIPTION
## Summary
- add the dotfiles synchronization sidecar after obsidian-sync
- share the codex-workspace home volume and configure a five-minute sync interval

Refs: BOXP-86

## Validation
- kubectl --dry-run=client apply -f argoproj/codex-workspace/deployment.yaml
- kustomize build argoproj/codex-workspace
- git diff --check
- codex review --uncommitted