### PR TITLE
fix: remove duplicate dotfiles-sync sidecar (BOXP-86)

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -193,41 +193,6 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/boxp
-        - name: dotfiles-sync
-          image: ghcr.io/boxp/arch/codex-workspace:latest
-          imagePullPolicy: Always
-          command:
-            - /bin/bash
-            - -c
-            - |
-              exec /opt/codex-workspace/dotfiles-sync.sh
-          env:
-            - name: HOME
-              value: /home/boxp
-            - name: DOTFILES_DIR
-              value: /home/boxp/ghq/github.com/boxp/dotfiles
-            - name: DOTFILES_REPO
-              value: https://github.com/boxp/dotfiles
-            - name: SYNC_INTERVAL
-              value: "300"
-          securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
-            allowPrivilegeEscalation: false
-            capabilities:
-              add: ["SETUID", "SETGID"]
-              drop: ["ALL"]
-            readOnlyRootFilesystem: false
-          resources:
-            requests:
-              cpu: "25m"
-              memory: "64Mi"
-            limits:
-              cpu: "250m"
-              memory: "256Mi"
-          volumeMounts:
-            - name: home
-              mountPath: /home/boxp
         - name: obsidian-task-board-draft
           image: ghcr.io/boxp/arch/codex-workspace:latest
           imagePullPolicy: Always


### PR DESCRIPTION
## Summary

- Removes the `dotfiles-sync` sidecar container added in #721
- The same script is already launched by `entrypoint.sh` in `boxp/arch` as a background process running as the `boxp` user (uid 1000) via `runuser`

## Why remove the sidecar?

Having both created:
1. **Race condition**: two processes writing to the same git repository simultaneously
2. **Root ownership bug**: the sidecar ran as `runAsUser: 0` (root), meaning `git clone` and file writes would produce root-owned files in the home PVC, breaking subsequent access by the `boxp` user
3. **Redundancy**: the background-process approach in `entrypoint.sh` already satisfies the fault-isolation requirement — it runs as a non-blocking `&` job, so a sync failure does not kill the main workspace process

## Test plan
- [ ] Verify the codex-workspace pod starts without the dotfiles-sync sidecar
- [ ] Verify dotfiles are synced by the background process in the workspace container (check logs for `[dotfiles-sync]` entries)
- [ ] Verify `/home/boxp/ghq/github.com/boxp/dotfiles` is owned by `boxp:boxp` after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)