### PR TITLE
fix: Longhorn Volume CRをlonghornアプリに移動してPV作成エラーを修正 (BOXP-104)

### DIFF
--- a/argoproj/longhorn/application.yaml
+++ b/argoproj/longhorn/application.yaml
@@ -45,6 +45,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: longhorn-system
   syncPolicy:
+    automated: {}
     syncOptions:
       - CreateNamespace=true
       - Replace=true

--- a/argoproj/longhorn/kustomization.yaml
+++ b/argoproj/longhorn/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - cloudflare-deployment.yaml
   - settings.yaml
   - recurring-jobs.yaml
+  - palserver-volume.yaml

--- a/argoproj/longhorn/palserver-volume.yaml
+++ b/argoproj/longhorn/palserver-volume.yaml
@@ -2,7 +2,6 @@ apiVersion: longhorn.io/v1beta2
 kind: Volume
 metadata:
   name: palserver-saved-claim-v2
-  namespace: longhorn-system
 spec:
   fromBackup: "s3://boxp-longhorn-backup@ap-northeast-1/?backup=backup-cfad6afbebd74a66&volume=pvc-085699a2-44ea-4bdd-baf6-ed37c93963ff"
   numberOfReplicas: 2

--- a/argoproj/palserver/kustomization.yaml
+++ b/argoproj/palserver/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - application.yaml
-- volume.yaml
 - pv.yaml
 - pvc-v2.yaml
 - deployment.yaml


### PR DESCRIPTION
## 問題

PR #726マージ後、`palserver` ArgoCDアプリが `volume.yaml`（Longhorn Volume CRD）を `longhorn-system` namespaceに適用しようとしていたが、`palserver` アプリの対象namespaceは `palserver` であるため、PVが正常に作成されなかった。

## 修正内容

1. `argoproj/palserver/volume.yaml` を `argoproj/longhorn/palserver-volume.yaml` に移動
   - `longhorn` ArgoCD app（対象: `longhorn-system`）で管理することで、Longhorn Volume CRが正しいnamespaceに適用される
   - `palserver` アプリからは `volume.yaml` を除外（PV・PVC・Deploymentのみ管理）

2. Longhorn ArgoCD Application に `automated` sync ポリシーを追加
   - マージ後にArgoが自動的に新しいVolume CRDを同期・適用するため、手動同期不要になる
   - `prune: false`（デフォルト）なので既存リソースは削除されない

## 修正フロー

1. ArgoCD `longhorn` app が自動同期で `palserver-volume.yaml` を `longhorn-system` に適用 → Longhornがバックアップからデータ復元開始
2. ArgoCD `palserver` app が `pv.yaml`・`pvc-v2.yaml`・`deployment.yaml` を同期
3. Longhorn Volume復元完了後、PV/PVCバインド完了
4. palserver Pod がRunning状態に移行

## Test plan

- [ ] ArgoCD `longhorn` app で `palserver-saved-claim-v2` Volume CRが `longhorn-system` に自動同期・作成されること
- [ ] Longhorn UI でボリュームのバックアップ復元が開始・完了すること
- [ ] `kubectl get pv palserver-saved-pv-v2` でPVが `Bound` 状態になること
- [ ] `kubectl get pod -n palserver` でPodがRunning状態になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)