### PR TITLE
fix: manage palserver image updates

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - hermes-agent.yaml
   - local-llm.yaml
   - stable-diffusion.yaml
+  - palserver.yaml


### PR DESCRIPTION
## 変更内容

- `palserver.yaml` を Image Updater の子 Kustomization に登録します。

## 原因と影響

`palserver` の ImageUpdater CR はファイルとして存在していましたが、子 Kustomization から参照されておらずクラスタへ適用されていませんでした。そのため新しい ECR イメージを検知できませんでした。

## 確認

- `kubectl kustomize argoproj/argocd-image-updater` で `palserver` ImageUpdater がレンダリングされることを確認
- `git diff --check`