### PR TITLE
fix: configure palserver ECR pull secret

### DIFF
--- a/argoproj/palserver/kustomization.yaml
+++ b/argoproj/palserver/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - pvc-v2.yaml
 - deployment.yaml
 - service.yaml
+- service-account.yaml

--- a/argoproj/palserver/service-account.yaml
+++ b/argoproj/palserver/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: palserver
+imagePullSecrets:
+  - name: regcred


### PR DESCRIPTION
## 変更内容

- `palserver` の default ServiceAccount に `regcred` を設定します。

## 背景

palserver namespace は ECR credential 更新後に作成されたため `regcred` がなく、ECR イメージを pull できませんでした。

## 確認

- `kubectl kustomize argoproj/palserver` で ServiceAccount がレンダリングされることを確認
- クラスタへ即時適用し、ECR credential を再配布済み