### PR TITLE
feat: add palserver-2 as independent second Palworld server instance

### DIFF
--- a/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - local-llm.yaml
   - stable-diffusion.yaml
   - palserver.yaml
+  - palserver-2.yaml

--- a/argoproj/argocd-image-updater/imageupdaters/palserver-2.yaml
+++ b/argoproj/argocd-image-updater/imageupdaters/palserver-2.yaml
@@ -1,0 +1,21 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: palserver-2
+  namespace: argocd
+spec:
+  applicationRefs:
+    - namePattern: "palserver-2"
+      images:
+        - alias: "myimage"
+          imageName: "839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/palserver:latest"
+          commonUpdateSettings:
+            updateStrategy: "newest-build"
+            pullSecret: "pullsecret:argocd/regcred"
+          manifestTargets:
+            kustomize:
+              name: "839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/palserver"
+  writeBackConfig:
+    method: "git:secret:argocd/repo-lolice"
+    gitConfig:
+      branch: "main"

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -36,3 +36,4 @@ resources:
 - kube-vip/application.yaml
 - tailscale-operator/application.yaml
 - palserver/application.yaml
+- palserver-2/application.yaml

--- a/argoproj/palserver-2/application.yaml
+++ b/argoproj/palserver-2/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: palserver-2
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:boxp/lolice.git
+    targetRevision: main
+    path: argoproj/palserver-2
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: palserver-2
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/argoproj/palserver-2/deployment.yaml
+++ b/argoproj/palserver-2/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: palserver-2
+  namespace: palserver-2
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: palserver-2
+  template:
+    metadata:
+      labels:
+        app: palserver-2
+    spec:
+      securityContext:
+        fsGroup: 65532
+      containers:
+      - name: palserver-2
+        image: 839695154978.dkr.ecr.ap-northeast-1.amazonaws.com/palserver:a1475970bfd9050f180d7d76cc280dabad937f16
+        ports:
+        - containerPort: 8211
+          protocol: UDP
+        volumeMounts:
+        - name: saved-volume
+          mountPath: /home/nonroot/PalServer/Pal/Saved
+        resources:
+          limits:
+            cpu: 3500m
+            memory: 8Gi
+          requests:
+            cpu: 1000m
+            memory: 8Gi
+      volumes:
+      - name: saved-volume
+        persistentVolumeClaim:
+          claimName: palserver-2-saved-claim
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - golyat-1

--- a/argoproj/palserver-2/kustomization.yaml
+++ b/argoproj/palserver-2/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml
+- volume.yaml
+- pv.yaml
+- pvc.yaml
+- deployment.yaml
+- service.yaml
+- service-account.yaml

--- a/argoproj/palserver-2/namespace.yaml
+++ b/argoproj/palserver-2/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: palserver-2

--- a/argoproj/palserver-2/pv.yaml
+++ b/argoproj/palserver-2/pv.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: palserver-2-saved-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: longhorn
+  csi:
+    driver: driver.longhorn.io
+    fsType: ext4
+    volumeHandle: palserver-2-saved-claim
+    volumeAttributes:
+      numberOfReplicas: "2"
+  claimRef:
+    namespace: palserver-2
+    name: palserver-2-saved-claim

--- a/argoproj/palserver-2/pvc.yaml
+++ b/argoproj/palserver-2/pvc.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: palserver-2-saved-claim
+  namespace: palserver-2
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: longhorn
+  volumeName: palserver-2-saved-pv
+  resources:
+    requests:
+      storage: 1Gi

--- a/argoproj/palserver-2/service-account.yaml
+++ b/argoproj/palserver-2/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: palserver-2
+imagePullSecrets:
+  - name: regcred

--- a/argoproj/palserver-2/service.yaml
+++ b/argoproj/palserver-2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: palserver-2
+  namespace: palserver-2
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.10.100
+  selector:
+    app: palserver-2
+  ports:
+  - protocol: UDP
+    port: 8211
+    targetPort: 8211

--- a/argoproj/palserver-2/volume.yaml
+++ b/argoproj/palserver-2/volume.yaml
@@ -1,0 +1,10 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: palserver-2-saved-claim
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: 2
+  size: "1073741824"
+  accessMode: rwo
+  frontend: blockdev


### PR DESCRIPTION
## Summary

BOXP-105 の実装: 既存の `palserver` と独立した第2 Palworld サーバーインスタンス `palserver-2` を追加。

- `argoproj/palserver-2/` に全マニフェストを作成
  - `namespace.yaml` - palserver-2 Namespace
  - `deployment.yaml` - 1 replica, golyat-1 ノード固定, CPU 3500m/1000m, Memory 8Gi
  - `service.yaml` - LoadBalancer IP: **192.168.10.100** (重複なし確認済み)
  - `pvc.yaml` - PVC `palserver-2-saved-claim` (1Gi, Longhorn)
  - `pv.yaml` - PV `palserver-2-saved-pv` (Longhorn CSI)
  - `volume.yaml` - Longhorn Volume `palserver-2-saved-claim` (新規空ボリューム)
  - `service-account.yaml` - ECR pull secret 付き ServiceAccount
  - `application.yaml` - ArgoCD Application (自動同期有効)
  - `kustomization.yaml`
- `argoproj/argocd-image-updater/imageupdaters/palserver-2.yaml` を追加 (イメージ自動更新)
- `argoproj/argocd-image-updater/imageupdaters/kustomization.yaml` に `palserver-2.yaml` を追加
- `argoproj/kustomization.yaml` に `palserver-2/application.yaml` を追加

## 判断メモ

- 初期ボリューム: 新規空ボリューム（既存 palserver データとの独立性を確保するため `fromBackup` なし）
- ノード配置: `golyat-1` 固定（既存 palserver と同じ。リソース競合が問題になる場合はノード変更要）

## Test plan

- [ ] ArgoCD UI で `palserver-2` Application が Healthy / Synced になることを確認
- [ ] `kubectl get svc -n palserver-2` で LoadBalancer IP `192.168.10.100` が割り当てられることを確認
- [ ] `kubectl get pvc -n palserver-2` で PVC が Bound になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)