### PR TITLE
chore: remove palserver-2 node affinity

### DIFF
--- a/argoproj/palserver-2/deployment.yaml
+++ b/argoproj/palserver-2/deployment.yaml
@@ -37,12 +37,3 @@ spec:
       - name: saved-volume
         persistentVolumeClaim:
           claimName: palserver-2-saved-claim
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                - golyat-1


### PR DESCRIPTION
## 変更内容

`palserver-2` Deployment の `golyat-1` への必須 node affinity を削除します。

## 背景

Palworld のユーザー ID がノード移動で初期化される懸念が解消されたため、任意のスケジュール可能ノードへ配置できるようにします。

## 影響

保存データは既存の Longhorn RWO PVC を継続して使用します。`palserver`（1台目）は変更しません。

## 確認

- `kubectl kustomize argoproj/palserver-2`
- `kubectl apply --dry-run=client --validate=true -f <rendered manifests>`
