### PR TITLE
feat(arc): LoliceクラスタへARC（actions-runner-controller）をArgoCD経由でデプロイ [BOXP-113]

### DIFF
--- a/argoproj/actions-runner-controller/controller/application.yaml
+++ b/argoproj/actions-runner-controller/controller/application.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-controller
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/boxp/lolice
+      targetRevision: main
+      ref: lolice
+    - repoURL: ghcr.io/actions/actions-runner-controller-charts
+      targetRevision: 0.9.3
+      chart: gha-runner-scale-set-controller
+      helm:
+        valueFiles:
+          - $lolice/argoproj/actions-runner-controller/controller/helm/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-systems
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argoproj/actions-runner-controller/controller/helm/values.yaml
+++ b/argoproj/actions-runner-controller/controller/helm/values.yaml
@@ -1,0 +1,15 @@
+# ARC Controller (gha-runner-scale-set-controller) Helm values
+# Ref: https://github.com/actions/actions-runner-controller/tree/main/charts/gha-runner-scale-set-controller
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+metrics:
+  controllerManagerAddr: ":8080"
+  listenerAddr: ":8080"
+  listenerEndpoint: "/metrics"

--- a/argoproj/actions-runner-controller/runner-scale-set/application.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/application.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/boxp/lolice
+      targetRevision: main
+      ref: lolice
+    - repoURL: ghcr.io/actions/actions-runner-controller-charts
+      targetRevision: 0.9.3
+      chart: gha-runner-scale-set
+      helm:
+        valueFiles:
+          - $lolice/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
+    - path: argoproj/actions-runner-controller/runner-scale-set
+      repoURL: https://github.com/boxp/lolice
+      targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argoproj/actions-runner-controller/runner-scale-set/external-secret.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/external-secret.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: arc-github-app-secret
+  namespace: arc-runners
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: arc-github-app-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: github_app_id
+      remoteRef:
+        key: /lolice/arc/github-app-id
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: /lolice/arc/github-app-installation-id
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: /lolice/arc/github-app-private-key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
@@ -15,8 +15,9 @@ githubConfigUrl: "https://github.com/boxp"
 githubConfigSecret: "arc-github-app-secret"
 
 # ARC コントローラーの ServiceAccount 情報
-controllerServiceAccountNamespace: arc-systems
-controllerServiceAccountName: arc-gha-rs-controller
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-controller-gha-rs-controller
 
 minRunners: 0
 maxRunners: 4

--- a/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
@@ -1,0 +1,35 @@
+# ARC Runner Scale Set (gha-runner-scale-set) Helm values
+# Ref: https://github.com/actions/actions-runner-controller/tree/main/charts/gha-runner-scale-set
+#
+# githubConfigSecret は ExternalSecret (arc-github-app-secret) で SSM から注入する。
+# GitHub App を以下の手順で作成してから SSM へ格納すること:
+#   1. GitHub Settings > Developer Settings > GitHub Apps でアプリ作成
+#   2. 必要権限: Actions (R/W), Administration (R/W for runners), Metadata (R)
+#   3. boxp organization にインストール
+#   4. App ID, Installation ID, Private Key を SSM へ格納:
+#      - /lolice/arc/github-app-id
+#      - /lolice/arc/github-app-installation-id
+#      - /lolice/arc/github-app-private-key
+
+githubConfigUrl: "https://github.com/boxp"
+githubConfigSecret: "arc-github-app-secret"
+
+# ARC コントローラーの ServiceAccount 情報
+controllerServiceAccountNamespace: arc-systems
+controllerServiceAccountName: arc-gha-rs-controller
+
+minRunners: 0
+maxRunners: 4
+
+template:
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 4Gi

--- a/argoproj/actions-runner-controller/runner-scale-set/kustomization.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - external-secret.yaml

--- a/argoproj/argocd/base/helm-repo-arc.yaml
+++ b/argoproj/argocd/base/helm-repo-arc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: helm-repo-arc
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: arc
+  url: ghcr.io/actions/actions-runner-controller-charts
+  type: helm
+  enableOCI: "true"

--- a/argoproj/argocd/kustomization.yaml
+++ b/argoproj/argocd/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - base/external-secrets.yaml
 - base/external-secret-repo.yaml
 - base/cloudflared-api.yaml
+- base/helm-repo-arc.yaml
 patchesStrategicMerge:
 - overlays/argocd-redis-network-policy.yaml
 - overlays/argocd-repo-server-network-policy.yaml

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -37,3 +37,5 @@ resources:
 - tailscale-operator/application.yaml
 - palserver/application.yaml
 - palserver-2/application.yaml
+- actions-runner-controller/controller/application.yaml
+- actions-runner-controller/runner-scale-set/application.yaml


### PR DESCRIPTION
## Summary

BOXP-113: Lolice（自宅k8sクラスタ）にGitHub Actions self-hosted runner（ARC）をArgoCD経由でデプロイするHelmアプリ定義を追加。

boxp/arch PR #11237（マージ済み）でarch側の準備（actionlint設定・ドキュメント）は完了しており、本PRはlolice側のArgoCD管理Helm定義の実装。

## 変更内容

### 新規ファイル

- `argoproj/actions-runner-controller/controller/application.yaml` — ARC controller ArgoCD Application（arc-systemsネームスペース）
- `argoproj/actions-runner-controller/controller/helm/values.yaml` — controller Helm values（リソース制限設定）
- `argoproj/actions-runner-controller/runner-scale-set/application.yaml` — arc-runners スケールセット ArgoCD Application
- `argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml` — ランナー設定（boxp org対象、maxRunners=4）
- `argoproj/actions-runner-controller/runner-scale-set/external-secret.yaml` — GitHub App認証情報をSSMから取得
- `argoproj/actions-runner-controller/runner-scale-set/kustomization.yaml`
- `argoproj/argocd/base/helm-repo-arc.yaml` — OCI Helmリポジトリ（ghcr.io/actions/actions-runner-controller-charts）をArgoCDへ登録

### 更新ファイル

- `argoproj/kustomization.yaml` — 新規ApplicationをArgoCD管理下に追加
- `argoproj/argocd/kustomization.yaml` — OCI Helmリポジトリ Secret を追加

## 手動設定が必要な事項（このPRマージ前後に実施）

1. **GitHub App作成**: GitHub Settings > Developer Settings > GitHub Apps
   - 必要権限: Actions (R/W), Self-hosted runners (R/W), Metadata (R)
   - boxp organizationにインストール
2. **SSM Parameter Store格納**:
   - `/lolice/arc/github-app-id`
   - `/lolice/arc/github-app-installation-id`  
   - `/lolice/arc/github-app-private-key`
3. **ARC稼働確認後**: boxp/archのworkflowの`runs-on`を`arc-runners`に切替（別PR）

## 構成詳細

- ARC Helm chart: `ghcr.io/actions/actions-runner-controller-charts` v0.9.3
- ランナー対象: `https://github.com/boxp`（org全体）
- スケール: 0〜4 runners（idle時ゼロスケール）
- リソース: requests 500m/512Mi、limits 2000m/4Gi（golyat-1〜4向け）
- 認証: ExternalSecret → AWS SSM Parameter Store

🤖 Generated with [Claude Code](https://claude.ai/claude-code)