### PR TITLE
fix(arc): runner/listenerポッドをamd64ワーカーノード(golyat)に配置 [BOXP-113]

### DIFF
--- a/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
@@ -4,7 +4,8 @@
 # githubConfigSecret は ExternalSecret (arc-github-app-secret) で SSM から注入する。
 # GitHub App を以下の手順で作成してから SSM へ格納すること:
 #   1. GitHub Settings > Developer Settings > GitHub Apps でアプリ作成
-#   2. 必要権限: Actions (R/W), Administration (R/W for runners), Metadata (R)
+#   2. 必要権限: Actions (R/W), Administration (R/W for runners), Metadata (R),
+#      Organization > Self-hosted runners (R/W) ※ org レベルランナーに必須
 #   3. boxp organization にインストール
 #   4. App ID, Installation ID, Private Key を SSM へ格納:
 #      - /lolice/arc/github-app-id
@@ -22,8 +23,17 @@ controllerServiceAccount:
 minRunners: 0
 maxRunners: 4
 
+# リスナー Pod を amd64 ワーカーノード (golyat) に配置
+listenerTemplate:
+  spec:
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 template:
   spec:
+    # ランナー Pod を amd64 ワーカーノード (golyat) に配置
+    nodeSelector:
+      kubernetes.io/arch: amd64
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest


### PR DESCRIPTION
## Summary

ARC runnerが起動しない問題の修正。runner/listener PodにnodeSelectorを追加し、amd64ワーカーノード(golyat-1〜4)のみに配置するよう制限する。

**根本原因（推定）:**
- `shanghai-1〜3`はOrange Pi Zero 3（ARM64/aarch64）のcontrollerノード
- nodeSelectorなしの場合、ARC listenerやrunner PodがARM64ノードに割り当てられ、アーキテクチャ不一致またはリソース不足で起動失敗する可能性がある
- `codex-workspace`等の既存Deploymentと同様に`kubernetes.io/arch: amd64`を追加

**変更内容:**
- `listenerTemplate.spec.nodeSelector: kubernetes.io/arch: amd64` を追加（ARC listenerポッドをgolyatノードに配置）
- `template.spec.nodeSelector: kubernetes.io/arch: amd64` を追加（GitHub Actionsランナーポッドをgolyatノードに配置）
- コメントにorg-level runnerに必要な`Organization > Self-hosted runners`権限を追記

**関連:**
- arch PR #11245（ansible CI → arc-runnersへの切替）はこのPRマージ後にCIが通る見込み
- BOXP-113チケット

## Test plan

- [ ] ArgoCD diffがクリーンに通ること
- [ ] マージ・sync後にarc-systemsおよびarc-runnersネームスペースのPodがRunningになること
- [ ] `kubectl -n arc-runners get pods` でlistener PodがRunningになること
- [ ] arch PR #11245のCIジョブ（plan）がarc-runnersで実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)