### PR TITLE
fix(arc): add repository runner scale sets

### DIFF
--- a/argoproj/actions-runner-controller/runner-scale-set-is01-linux/application.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-is01-linux/application.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners-is01-linux
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/boxp/lolice
+      targetRevision: main
+      ref: lolice
+    - repoURL: ghcr.io/actions/actions-runner-controller-charts
+      targetRevision: 0.9.3
+      chart: gha-runner-scale-set
+      helm:
+        valueFiles:
+          - $lolice/argoproj/actions-runner-controller/runner-scale-set-is01-linux/helm/values.yaml
+    - path: argoproj/actions-runner-controller/runner-scale-set-is01-linux
+      repoURL: https://github.com/boxp/lolice
+      targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners-is01-linux
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argoproj/actions-runner-controller/runner-scale-set-is01-linux/external-secret.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-is01-linux/external-secret.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: arc-github-app-secret
+  namespace: arc-runners-is01-linux
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: arc-github-app-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: github_app_id
+      remoteRef:
+        key: /lolice/arc/github-app-id
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: /lolice/arc/github-app-installation-id
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: /lolice/arc/github-app-private-key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/argoproj/actions-runner-controller/runner-scale-set-is01-linux/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-is01-linux/helm/values.yaml
@@ -1,0 +1,24 @@
+# ARC Runner Scale Set for boxp/is01-linux.
+# GitHub App credentials are synchronized from SSM by ExternalSecret.
+githubConfigUrl: "https://github.com/boxp/is01-linux"
+githubConfigSecret: "arc-github-app-secret"
+
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-controller-gha-rs-controller
+
+minRunners: 0
+maxRunners: 4
+
+template:
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 4Gi

--- a/argoproj/actions-runner-controller/runner-scale-set-is01-linux/kustomization.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-is01-linux/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - external-secret.yaml

--- a/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
@@ -5,13 +5,15 @@
 # GitHub App を以下の手順で作成してから SSM へ格納すること:
 #   1. GitHub Settings > Developer Settings > GitHub Apps でアプリ作成
 #   2. 必要権限: Actions (R/W), Administration (R/W for runners), Metadata (R)
-#   3. boxp organization にインストール
+#   3. 対象の GitHub アカウントまたは Organization にインストール
 #   4. App ID, Installation ID, Private Key を SSM へ格納:
 #      - /lolice/arc/github-app-id
 #      - /lolice/arc/github-app-installation-id
 #      - /lolice/arc/github-app-private-key
 
-githubConfigUrl: "https://github.com/boxp"
+# 個人アカウントでは組織全体の Runner Scale Set は利用できないため、
+# GitHub のリポジトリ単位で Scale Set を設定する。
+githubConfigUrl: "https://github.com/boxp/arch"
 githubConfigSecret: "arc-github-app-secret"
 
 # ARC コントローラーの ServiceAccount 情報

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -39,3 +39,4 @@ resources:
 - palserver-2/application.yaml
 - actions-runner-controller/controller/application.yaml
 - actions-runner-controller/runner-scale-set/application.yaml
+- actions-runner-controller/runner-scale-set-is01-linux/application.yaml


### PR DESCRIPTION
BOXP-113: 個人アカウント配下の `boxp/arch` と `boxp/is01-linux` に対し、リポジトリ単位の ARC Runner Scale Set を構成します。既存の `arc-runners` を `arch` 向けに切り替え、`is01-linux` 用の Application・ExternalSecret・Helm values を追加します。