### PR TITLE
fix(arc): start runner process explicitly

### DIFF
--- a/argoproj/actions-runner-controller/runner-scale-set-is01-linux/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-is01-linux/helm/values.yaml
@@ -15,6 +15,8 @@ template:
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest
+        command:
+          - /home/runner/run.sh
         resources:
           requests:
             cpu: 500m

--- a/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set/helm/values.yaml
@@ -29,6 +29,8 @@ template:
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest
+        command:
+          - /home/runner/run.sh
         resources:
           requests:
             cpu: 500m


### PR DESCRIPTION
ARC Runner イメージの既定コマンドが `/bin/bash` のため、Runner コンテナが即時終了していた。`/home/runner/run.sh` を両リポジトリ向け Scale Set に明示する。