### PR TITLE
feat(arc): enable DIND for image builds

### DIFF
--- a/argoproj/actions-runner-controller/runner-scale-set-arch/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-arch/helm/values.yaml
@@ -8,9 +8,15 @@ controllerServiceAccount:
   namespace: arc-systems
   name: arc-controller-gha-rs-controller
 minRunners: 0
-maxRunners: 4
+maxRunners: 2
+
+containerMode:
+  type: dind
+
 template:
   spec:
+    nodeSelector:
+      lolice.io/gpu-worker: "true"
     containers:
     - name: runner
       image: ghcr.io/boxp/arch/arc-runner:sha-d92365b
@@ -18,8 +24,10 @@ template:
       - /home/runner/run.sh
       resources:
         requests:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 4
+          memory: 8Gi
+          ephemeral-storage: 100Gi
         limits:
-          cpu: 2000m
-          memory: 4Gi
+          cpu: 8
+          memory: 32Gi
+          ephemeral-storage: 250Gi


### PR DESCRIPTION
## Summary
- arc-runners-arch に privileged Docker-in-Docker を有効化
- GPU worker node へ配置し、image build 向けの CPU / memory / ephemeral-storage 制限を設定
- 同時 runner 数を2へ制限

## Verification
- helm template gha-runner-scale-set --version 0.9.3
- DIND sidecar / privileged / resource rendering を確認