### PR TITLE
fix(arc): serialize image build runners

### DIFF
--- a/argoproj/actions-runner-controller/runner-scale-set-arch/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-arch/helm/values.yaml
@@ -8,7 +8,10 @@ controllerServiceAccount:
   namespace: arc-systems
   name: arc-controller-gha-rs-controller
 minRunners: 0
-maxRunners: 2
+# These image builds are intentionally serialized on the single GPU worker.
+# Its CPU is heavily reserved by other workloads, so a modest request lets the
+# runner schedule while retaining headroom through the 8 CPU limit.
+maxRunners: 1
 template:
   spec:
     nodeSelector:
@@ -43,7 +46,7 @@ template:
         mountPath: /var/run
       resources:
         requests:
-          cpu: 4
+          cpu: 2
           memory: 8Gi
           ephemeral-storage: 100Gi
         limits:


### PR DESCRIPTION
golyat-4 の予約 CPU が 13.2/16 CPU のため、4 CPU request の ARC runner がスケジュール不能でした。

image build は単一ノードで直列実行とし、`maxRunners: 1` と `requests.cpu: 2` に設定します。8 CPU limit は維持します。

検証: `helm template`; `git diff --check`