### PR TITLE
refactor(arc): remove DIND from GPU runners

### DIFF
--- a/argoproj/actions-runner-controller/runner-scale-set-arch/helm/values.yaml
+++ b/argoproj/actions-runner-controller/runner-scale-set-arch/helm/values.yaml
@@ -16,34 +16,11 @@ template:
   spec:
     nodeSelector:
       lolice.io/gpu-worker: "true"
-    initContainers:
-    - name: init-dind-externals
-      image: ghcr.io/boxp/arch/arc-runner:sha-b85cf91
-      command:
-      - cp
-      args:
-      - -r
-      - -v
-      - /home/runner/externals/.
-      - /home/runner/tmpDir/
-      volumeMounts:
-      - name: dind-externals
-        mountPath: /home/runner/tmpDir
     containers:
     - name: runner
       image: ghcr.io/boxp/arch/arc-runner:sha-a938c1e
       command:
       - /home/runner/run.sh
-      env:
-      - name: DOCKER_HOST
-        value: unix:///var/run/docker.sock
-      - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
-        value: "120"
-      volumeMounts:
-      - name: work
-        mountPath: /home/runner/_work
-      - name: dind-sock
-        mountPath: /var/run
       resources:
         requests:
           cpu: 2
@@ -53,32 +30,3 @@ template:
           cpu: 8
           memory: 32Gi
           ephemeral-storage: 250Gi
-    - name: dind
-      image: docker:dind
-      args:
-      - dockerd
-      - --host=unix:///var/run/docker.sock
-      - --group=$(DOCKER_GROUP_GID)
-      # The node filesystem cannot use containerd's overlay snapshotter from
-      # within DIND. Use Docker's portable vfs backend instead.
-      - --feature=containerd-snapshotter=false
-      - --storage-driver=vfs
-      env:
-      - name: DOCKER_GROUP_GID
-        value: "123"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: work
-        mountPath: /home/runner/_work
-      - name: dind-sock
-        mountPath: /var/run
-      - name: dind-externals
-        mountPath: /home/runner/externals
-    volumes:
-    - name: work
-      emptyDir: {}
-    - name: dind-sock
-      emptyDir: {}
-    - name: dind-externals
-      emptyDir: {}


### PR DESCRIPTION
Orange Pi ビルドを GitHub-hosted runner に戻したため、`arc-runners-arch` には Docker-in-Docker が不要になります。

privileged DIND・関連 volume/env を削除し、GPU Worker 専用の通常 ARC runner に戻します。

検証: `helm template`; `git diff --check`