### PR TITLE
fix(nfd): node-feature-discovery-masterのmemory limitを256Miに修正し、workerノードへ移動 [BOXP-116]

### DIFF
--- a/argoproj/node-feature-discovery/application.yaml
+++ b/argoproj/node-feature-discovery/application.yaml
@@ -13,6 +13,21 @@ spec:
     chart: node-feature-discovery
     helm:
       values: |
+        master:
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 500m
+            requests:
+              memory: 128Mi
+              cpu: 100m
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
         worker:
           tolerations:
             - key: lolice.io/gpu-worker


### PR DESCRIPTION
## Summary

BOXP-116の対応。shanghai-1のOOMKill問題を解決するため、node-feature-discovery-masterの設定を修正。

- `master.resources.limits.memory`: `4Gi` → `256Mi`（即時対応）
  - shanghai-1の総メモリ3.83 GiBを超えていたため断続的なOOMKillが発生していた
- `master.affinity.nodeAffinity`: コントロールプレーン（`node-role.kubernetes.io/control-plane`が存在しないノード）のみにスケジュールするよう制限（根本対応）
  - node-feature-discovery-masterをworkerノード（golyat-*）に移動し、コントロールプレーン（shanghai-*）を汚染しない

## Expected Impact

- shanghai-1のメモリリミット合計: **117%（4486Mi / 3831Mi）→ 約10%程度**
- kube-apiserver / kube-controller-manager / kube-schedulerのOOMKill（exit code 137）解消
- 関連: BOXP-115（調査チケット）の知見を反映

## Test plan

- [ ] ArgoCD Syncが成功し、新しいmasterのPodがworkerノード（golyat-*）に再スケジュールされることを確認
- [ ] `kubectl describe node shanghai-1` でメモリリミット合計が100%以下になっていることを確認
- [ ] 24時間後にkube-apiserverの再起動カウントが増加していないことを確認
- [ ] node-feature-discovery-masterのPodが正常動作していることを確認（`kubectl get pods -n node-feature-discovery`）

## Files Changed

- `argoproj/node-feature-discovery/application.yaml`: masterリソース設定とnodeAffinityを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)