### PR TITLE
feat(codex-workspace): mosh 対応と IS01 鍵の永続化

### DIFF
--- a/argoproj/codex-workspace/deployment.yaml
+++ b/argoproj/codex-workspace/deployment.yaml
@@ -33,6 +33,9 @@ spec:
               ln -s /etc/pi-agent-config/models.json /home/boxp/.pi/agent/models.json
               curl -fsSL https://github.com/boxp.keys -o /home/boxp/.ssh/authorized_keys
               test -s /home/boxp/.ssh/authorized_keys
+              # IS01(実機Codex端末)専用の公開鍵。github.com/boxp.keys には含まれず、
+              # authorized_keys は毎起動で上書きされるため、ここで追記して永続化する。
+              printf '%s\n' 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+VDgWCQqbWKHLHa/Wz2Up4duDjPYJ/GCx2hsfU/+s/ is01-terminal-20260712' >> /home/boxp/.ssh/authorized_keys
               chown -R 1000:1000 /home/boxp/.ssh
               chown -h 1000:1000 /home/boxp/.pi/agent/models.json
               chmod 700 /home/boxp/.ssh
@@ -75,6 +78,9 @@ spec:
               containerPort: 2222
             - name: even-terminal
               containerPort: 3456
+            - name: mosh
+              containerPort: 60001
+              protocol: UDP
           env:
             - name: EVEN_TERMINAL_PORT
               value: "3456"

--- a/argoproj/codex-workspace/networkpolicy.yaml
+++ b/argoproj/codex-workspace/networkpolicy.yaml
@@ -37,6 +37,23 @@ spec:
         ports:
           - 2222
           - 3456
+    # mosh (IS01実機Codex端末の安定transport) の UDP データグラム。
+    # SSHで起動された mosh-server が待ち受ける 60001/UDP を LAN と SNAT元から許可する。
+    - action: Allow
+      protocol: UDP
+      source:
+        nets:
+          - 192.168.10.0/24
+          - 192.178.60.120/32
+          - 192.178.252.77/32
+          - 192.178.151.187/32
+          - 192.178.123.0/32
+          - 192.178.46.166/32
+          - 192.178.48.194/32
+          - 192.178.80.45/32
+      destination:
+        ports:
+          - 60001
   egress:
     - action: Allow
       protocol: UDP

--- a/argoproj/codex-workspace/service.yaml
+++ b/argoproj/codex-workspace/service.yaml
@@ -15,3 +15,7 @@ spec:
     - name: even-terminal
       port: 3456
       targetPort: even-terminal
+    - name: mosh
+      port: 60001
+      targetPort: mosh
+      protocol: UDP


### PR DESCRIPTION
## 背景
IS01(実機Codex端末)からWiFi経由でcodex-workspaceを操作すると、WiFi受信経路のデータ破損でSSHが integrity error 切断し実用にならない。破損・切断に強い mosh(UDP+状態同期)を使えるようにする。

調査の過程で、`fetch-ssh-keys` initContainer が `authorized_keys` を `github.com/boxp.keys` で毎起動上書きしており、IS01専用鍵が pod 再起動のたびに消えることも判明した(現行SSHのdurable化にも影響)。

## 変更
- `service.yaml`: LoadBalancer に mosh 用 `60001/UDP` を追加。
- `deployment.yaml`:
  - mosh の containerPort(`60001/UDP`)を公開。
  - `fetch-ssh-keys` に IS01公開鍵(`is01-terminal-20260712`)の追記を追加し、authorized_keys 上書き後も残るよう永続化。
- `networkpolicy.yaml`: `60001/UDP` の ingress を LAN(`192.168.10.0/24`)と kube-vip SNAT元から許可(既存 TCP ingress と同じ送信元集合)。

## 関連 / 前提
- mosh-server は arch の codex-workspace Dockerfile に追加(別PR)。image は `:latest` 参照のため、arch マージ後の再ビルドで反映される。
- 反映後、pod ロールアウトで IS01鍵の永続化と mosh 対応が有効になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)