### PR TITLE
feat(hermes-agent): コハコのプロアクティブ秘書化 - Calendar/Gmail連携とcalendar_reminder追加 [BOXP-133]

### DIFF
--- a/argoproj/hermes-agent/deployment.yaml
+++ b/argoproj/hermes-agent/deployment.yaml
@@ -49,6 +49,17 @@ spec:
                 chmod 0644 "$skill_dir/SKILL.md"
                 chmod 0755 "$skill_dir/bin/task-board.bb"
               fi
+              if [ ! -f /opt/data/scripts/calendar_reminder.sh ]; then
+                mkdir -p /opt/data/scripts
+                cat > /opt/data/scripts/calendar_reminder.sh << 'SCRIPT_EOF'
+#!/bin/sh
+set -eu
+/opt/data/scripts/quiet_gate.sh || exit 0
+cd /home/boxp/Documents/obsidian-headless/BOXP && exec bb calendar_reminder.clj
+SCRIPT_EOF
+                chmod 0755 /opt/data/scripts/calendar_reminder.sh
+                chown 1000:10000 /opt/data/scripts/calendar_reminder.sh
+              fi
               chown 1000:10000 \
                 /opt/data \
                 /opt/data/Documents \

--- a/docs/project_docs/BOXP-133/plan.md
+++ b/docs/project_docs/BOXP-133/plan.md
@@ -1,0 +1,130 @@
+# BOXP-133: hermes-agent コハコのプロアクティブ秘書化 実装プラン
+
+## 実装サマリー
+
+hermes-agent（コハコ）に Gmail・Google Calendar 連携を追加し、cronによる定期的なプロアクティブ通知を実現する。
+
+## 変更内容
+
+### 1. Obsidian vault変更（Obsidian Syncで自動反映）
+
+#### `morning_report.clj` （更新）
+
+- Google Calendar: 今日の予定を「【今日の予定】」セクションに追加
+- Gmail: 要対応メール（noreply系を除外したunread inbox）を「【要対応メール】」セクションに追加
+- 呼び出し: `/opt/data/.venv-google/bin/python /opt/data/skills/productivity/google-workspace/scripts/google_api.py`
+- トークン: `/home/boxp/google_token.json`
+
+#### `calendar_reminder.clj` （新規作成）
+
+- 開始まで25〜35分のGoogleカレンダーイベントを検索
+- 対象イベントがあれば「📅 30分後に〜が始まります。」と出力
+- 対象なし → 完全沈黙（何も出力しない）
+
+### 2. lolice k8s変更（このPR）
+
+#### `argoproj/hermes-agent/deployment.yaml` （更新）
+
+- init container に `calendar_reminder.sh` の配置ロジックを追加
+- `/opt/data/scripts/calendar_reminder.sh` が存在しない場合のみ作成（べき等）
+- 内容: `quiet_gate.sh` による静音制御 + `bb calendar_reminder.clj` 実行
+
+## 必要な手動作業（hermes-agent cron登録）
+
+以下の cron を hermes-agent（コハコ）に直接登録する必要がある。
+Telegram または hermes-agent ダッシュボードから実行すること。
+
+### Step A: 毎時メールチェック cron の復元
+
+```
+/schedule add
+  name: Hourly actionable-mail check (Kohako)
+  schedule: every 60 minutes
+  script: /opt/data/scripts/email_check.sh
+  no_agent: true
+  deliver: telegram
+```
+
+- 旧ID `8212921d18d2` と同設定
+- `quiet_gate.sh` によって 02:00〜09:00 JST は自動スキップされる
+
+### Step B: カレンダーリマインダー cron の追加
+
+```
+/schedule add
+  name: Calendar event reminder (30min before)
+  schedule: every 15 minutes
+  script: /opt/data/scripts/calendar_reminder.sh
+  no_agent: true
+  deliver: telegram
+```
+
+- `calendar_reminder.sh` が `/opt/data/scripts/` に存在することが前提（このPRのdeployで配置される）
+- 予定なし時は完全沈黙
+
+### Step C: 夕方サマリー cron の追加
+
+```
+/schedule add
+  name: Evening summary (weekday 18:00 JST)
+  schedule: 0 9 * * 1-5
+  prompt: |
+    コハコとして、以下を確認して200字以内でご主人さまにまとめをお届けください。
+    何も特筆すべきことがなければ沈黙してください。
+    1. 今日のGmail未対応メール: /opt/data/.venv-google/bin/python /opt/data/skills/productivity/google-workspace/scripts/google_api.py gmail search "is:unread is:inbox newer_than:1d" で確認
+    2. 明日のGoogleカレンダー予定: google_api.py calendar list で明日の予定を確認
+    3. Task Boardの未完了チケット: bb ~/.claude/skills/obsidian-task-board/bin/task-board.bb list-tickets で確認
+```
+
+### Step D: Xタイムライン監視 cron（xurl認証設定後に追加）
+
+前提: xurl インストール + OAuth設定完了後
+
+```
+/schedule add
+  name: X timeline context check
+  schedule: every 60 minutes
+  prompt: |
+    コハコとして、HOME=/opt/data/home xurl timeline -n 10 でご主人さまのXタイムラインを確認し、
+    日常的なコンテキスト（予定変更・気分・外出など）を把握してください。
+    特記事項がなければ沈黙してください。
+```
+
+## morning_report cron プロンプト確認
+
+既存の Morning Report cron (ID: `74a03bb016d3`) のプロンプトにはGmail確認の記述があるが、
+`morning_report.clj` の実装が天気+RSSのみだった。今回の更新でプロンプトと実装が一致する。
+cron のプロンプト変更は不要。
+
+## xurl 手動インストール手順（ユーザーがpod内で実施）
+
+```bash
+# xurlのインストール
+curl -fsSL https://raw.githubusercontent.com/xdevplatform/xurl/main/install.sh | HOME=/opt/data/home bash
+
+# OAuth認証
+HOME=/opt/data/home xurl auth apps add boxp --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+HOME=/opt/data/home xurl auth oauth2 --app boxp boxp
+HOME=/opt/data/home xurl auth default boxp
+
+# 動作確認
+HOME=/opt/data/home xurl timeline -n 5
+```
+
+## デプロイ順序
+
+1. このPRをmainにマージ → ArgoCDが hermes-agent を再デプロイ
+2. init container が `/opt/data/scripts/calendar_reminder.sh` を配置
+3. Obsidian Sync が `morning_report.clj` と `calendar_reminder.clj` を pod に反映
+4. hermes-agent の Telegram または Dashboard から cron Step A〜C を登録
+5. morning_report cron を手動トリガーして Calendar・Gmail セクションが出力されることを確認
+6. xurl インストール後に Step D を実施
+
+## 動作確認チェックリスト
+
+- [ ] morning_report.clj が Calendar・Gmail セクションを含む出力を生成すること
+- [ ] calendar_reminder.clj が予定あり時に通知し、なし時に沈黙すること
+- [ ] `/opt/data/scripts/calendar_reminder.sh` が pod 内に存在すること
+- [ ] 毎時メールチェック cron が再登録されていること
+- [ ] カレンダーリマインダー cron が登録されていること
+- [ ] 夕方サマリー cron が登録されていること


### PR DESCRIPTION
## Summary

BOXP-133 の実装PR。hermes-agent（コハコ）が Gmail・Google Calendar を活用してプロアクティブに動けるよう改善する。

**k8s変更（このPR）:**
- `argoproj/hermes-agent/deployment.yaml`: init container に `calendar_reminder.sh` のPVC配置ロジックを追加
  - `/opt/data/scripts/calendar_reminder.sh` をべき等で作成（既存ファイルがあればスキップ）
  - `quiet_gate.sh` で静音時間制御（02:00〜09:00 JST）、`bb calendar_reminder.clj` を実行

**Obsidian vault変更（Obsidian Sync経由で自動反映、このPRには含まない）:**
- `morning_report.clj`: 天気・ニュースに加えて「今日の予定（Google Calendar）」と「要対応メール（Gmail）」を追加
- `calendar_reminder.clj`: 新規作成 - 開始30分前のイベントを検知して通知、なければ沈黙

**手動作業（コハコへのTelegram/Dashboardで登録）:**
- 毎時メールチェック cron の復元（email_check.sh 使用、旧ID 8212921d18d2 と同設定）
- カレンダーリマインダー cron の追加（15分毎、calendar_reminder.sh 使用）
- 夕方サマリー cron の追加（平日 18:00 JST、LLMプロンプト型）
- 詳細手順: `docs/project_docs/BOXP-133/plan.md` 参照

## Test plan

- [ ] デプロイ後 `/opt/data/scripts/calendar_reminder.sh` がpod内に存在することを確認
- [ ] morning_report.clj を手動実行して Calendar・Gmail セクションが出力されることを確認
- [ ] calendar_reminder.clj を手動実行してイベントあり/なしの両パターンを確認
- [ ] cronをStep A〜C登録後、各通知が正常に届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)