### PR TITLE
fix(hermes-agent): Gmail検索引数を現行CLIへ更新 [BOXP-136]

### DIFF
--- a/argoproj/hermes-agent/configmap.yaml
+++ b/argoproj/hermes-agent/configmap.yaml
@@ -86,7 +86,7 @@ data:
       []
       (let [output (run-google-api "gmail" "search"
                                    "\"is:unread is:inbox newer_than:2d\""
-                                   "--max-results" "10")]
+                                   "--max" "10")]
         (when (and output (not (str/blank? output)))
           (let [emails (json/parse-string output true)]
             (when (seq emails)
@@ -228,7 +228,7 @@ data:
 
     ;; 朝のブリーフィングスクリプト
     ;; 天気・ニュース・今日のカレンダー予定・要対応メールを報告する
-    ;; hermes-bootstrap-version: v3-no-custom-memory-20260728
+    ;; hermes-bootstrap-version: v4-google-api-max-20260728
 
     (ns morning-report
       (:require [babashka.process :as proc]
@@ -314,7 +314,7 @@ data:
       (try
         (let [output (run-google-api "gmail" "search"
                                      "\"is:unread is:inbox newer_than:2d\""
-                                     "--max-results" "10")]
+                                     "--max" "10")]
           (when (and output (not (str/blank? output)))
             (let [emails (json/parse-string output true)
                   actionable (filter actionable? emails)]

--- a/argoproj/hermes-agent/deployment.yaml
+++ b/argoproj/hermes-agent/deployment.yaml
@@ -68,7 +68,7 @@ spec:
                 chown 1000:10000 "$VAULT_CALENDAR"
               fi
               VAULT_MORNING="/opt/data/Documents/obsidian-headless/BOXP/morning_report.clj"
-              if [ ! -f "$VAULT_MORNING" ] || ! grep -q "; hermes-bootstrap-version: v3-no-custom-memory-20260728" "$VAULT_MORNING"; then
+              if [ ! -f "$VAULT_MORNING" ] || ! grep -q "; hermes-bootstrap-version: v4-google-api-max-20260728" "$VAULT_MORNING"; then
                 cp /bootstrap/morning_report.clj "$VAULT_MORNING"
                 chmod 0644 "$VAULT_MORNING"
                 chown 1000:10000 "$VAULT_MORNING"

--- a/docs/project_docs/BOXP-136/plan.md
+++ b/docs/project_docs/BOXP-136/plan.md
@@ -1,0 +1,18 @@
+# BOXP-136: Gmail チェック用 Google API CLI 引数修正
+
+## 目的
+
+`google_api.py gmail search` の廃止済み `--max-results` を、現行 CLI が受け付ける `--max` に置換し、メールチェックと朝のレポートを復旧する。
+
+## 実施内容
+
+1. 実行中 pod の `google_api.py gmail search --help` で現行引数を確認する。
+2. hermes-agent ConfigMap 内の `email_check.clj` と `morning_report.clj` を `--max 10` に更新する。
+3. `morning_report.clj` のブートストラップ版を更新し、既存 PVC でも新しいスクリプトを再配置する。
+4. Kubernetes マニフェストと実行中 pod 上の CLI 呼び出しを検証する。
+
+## 検証基準
+
+- `google_api.py gmail search "is:unread" --max 10` が引数エラーなく実行できる。
+- ConfigMap と Deployment に `--max-results` が残らない。
+- YAML が構文解析できる。


### PR DESCRIPTION
## 概要

`google_api.py gmail search` に渡していた未対応の `--max-results 10` を、現行 CLI 仕様の `--max 10` に修正します。

## 原因と対応

実行中 pod の `google_api.py gmail search --help` で受け付ける引数が `--max MAX` であることを確認しました。`morning_report.clj` のブートストラップバージョンも更新し、既存 PVC へ修正版が再配置されるようにしています。

## 検証

- `kubectl apply --dry-run=client`（ConfigMap / Deployment）
- 修正後の一時スクリプトを実行中 pod 上で実行
  - `email_check.clj`: 正常終了
  - `morning_report.clj`: 正常終了
- `git diff --check`
