### PR TITLE
codex-workspace: mosh 用 UDP NodePort 30601 を追加 (IS01 WiFi)

### DIFF
--- a/argoproj/codex-workspace/service.yaml
+++ b/argoproj/codex-workspace/service.yaml
@@ -26,3 +26,7 @@ spec:
       port: 60001
       targetPort: mosh
       protocol: UDP
+      # Explicit UDP NodePort so IS01(WiFi) reaches mosh via a node real IP,
+      # bypassing the kube-vip VIP (whose virtual MAC drops WiFi datagrams).
+      # is01-mosh points mosh-client at <node-ip>:30601 with mosh-server -p 60001.
+      nodePort: 30601


### PR DESCRIPTION
## 背景
IS01(WiFi) は kube-vip LoadBalancer VIP(192.168.10.98) の仮想 MAC 宛データグラムが WiFi AP で落ちるため VIP 経由の mosh UDP が届かない（TCP は同理由で既に NodePort 30022 を使用）。

## 変更
mosh の `60001/UDP` に**明示 UDP nodePort 30601** を追加（純粋な追加、LoadBalancer/VIP 経路は無変更）。IS01 の `is01-mosh` は node 実IP:30022 で bootstrap → `mosh-server -p 60001` 固定 → `mosh-client <node-ip>:30601` で接続する。

## 検証
`kubectl kustomize` で mosh port=60001/nodePort=30601/protocol=UDP/targetPort=mosh を確認。ArgoCD 同期後、IS01→node実IP:30601/UDP で mosh 疎通を実機確認する。NetworkPolicy は 60001/UDP を 192.168.10.0/24 + tunnel IP から許可済み（nodePort SNAT もカバー想定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)