### PR TITLE
chore(etcd): defrag を定期自動化し descheduler の churn を削減

### DIFF
--- a/argoproj/descheduler/helm/values.yaml
+++ b/argoproj/descheduler/helm/values.yaml
@@ -46,7 +46,11 @@ namespaceOverride: ""
 commonLabels: {}
 
 cronJobApiVersion: "batch/v1"
-schedule: "*/2 * * * *"
+# 2分ごと(720回/日)は shanghai-* (Orange Pi Zero 3, rootfs=microSD) の etcd 書き込みを
+# 押し上げるだけの価値がない。1回ごとに Job/Pod の生成・更新・削除が etcd に書かれる。
+# 2026-08-01 の shanghai-1 ハング調査を受けて 30分ごと(48回/日)へ緩和した。
+# 詳細: docs/project_docs/shanghai-node-resilience/plan.md
+schedule: "*/30 * * * *"
 suspend: false
 # startingDeadlineSeconds: 200
 # successfulJobsHistoryLimit: 3

--- a/argoproj/etcd-defrag/application.yaml
+++ b/argoproj/etcd-defrag/application.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: etcd-defrag
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boxp/lolice.git
+    targetRevision: main
+    path: argoproj/etcd-defrag
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/argoproj/etcd-defrag/cronjob.yaml
+++ b/argoproj/etcd-defrag/cronjob.yaml
@@ -1,0 +1,120 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: etcd-defrag
+spec:
+  # 毎週日曜 04:00 JST。2026-08-04 時点で DB 626MB のうち 94% が未使用で、
+  # shanghai-* (Orange Pi Zero 3, rootfs=microSD) への書き込み増幅を押し上げていた。
+  # 詳細: docs/project_docs/shanghai-node-resilience/plan.md
+  schedule: "0 4 * * 0"
+  timeZone: Asia/Tokyo
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      # 完了した Job/Pod を残し続けると、削減したいはずの etcd 書き込みを自分で増やしてしまう。
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: etcd-defrag
+        spec:
+          restartPolicy: Never
+          # etcd は 127.0.0.1:2379 で待ち受けているため、CNI に依存せず host network で叩く。
+          hostNetwork: true
+          priorityClassName: system-cluster-critical
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+          securityContext:
+            # 証明書の秘密鍵が root:root 0600 のため root で読む必要がある。
+            runAsUser: 0
+            runAsGroup: 0
+          # etcd イメージは distroless でシェルを持たないため、シェルスクリプトは使えない。
+          # 代わりに initContainer を健全性ゲートとして使い、1 台でも落ちていれば
+          # defrag を実行しないようにする (defrag 中のメンバーはブロックするため、
+          # 既に 1 台落ちている状態で走らせると quorum を失う)。
+          initContainers:
+            - name: health-gate
+              # 第三者イメージは digest 固定 (argoproj/argocd-image-updater/imageupdaters/README.md)。
+              # etcd の秘密鍵を root で読むワークロードなので同一性を保証する。
+              # multi-arch manifest list の digest なので control-plane の arm64 でも解決される。
+              image: registry.k8s.io/etcd:3.6.8-0@sha256:397189418d1a00e500c0605ad18d1baf3b541a1004d768448c367e48071622e5
+              command: ["etcdctl"]
+              args:
+                - --endpoints=https://127.0.0.1:2379
+                - --cacert=/etc/etcd-certs/ca.crt
+                - --cert=/etc/etcd-certs/client.crt
+                - --key=/etc/etcd-certs/client.key
+                # 既定の 5s では Orange Pi Zero 3 上の MemberList が間に合わず
+                # DeadlineExceeded になる (実測)。
+                - --dial-timeout=15s
+                - --command-timeout=60s
+                - endpoint
+                - health
+                - --cluster
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 128Mi
+              volumeMounts: &etcdCertMounts
+                - name: etcd-ca
+                  mountPath: /etc/etcd-certs/ca.crt
+                  readOnly: true
+                - name: etcd-client-cert
+                  mountPath: /etc/etcd-certs/client.crt
+                  readOnly: true
+                - name: etcd-client-key
+                  mountPath: /etc/etcd-certs/client.key
+                  readOnly: true
+          containers:
+            # etcdctl defrag --cluster はメンバーを 1 台ずつ順番に処理し、
+            # 各メンバーの完了を待ってから次へ進む。同時にブロックされるのは常に 1 台なので
+            # 3 メンバー構成では quorum が維持される。
+            - name: defrag
+              image: registry.k8s.io/etcd:3.6.8-0@sha256:397189418d1a00e500c0605ad18d1baf3b541a1004d768448c367e48071622e5
+              command: ["etcdctl"]
+              args:
+                - --endpoints=https://127.0.0.1:2379
+                - --cacert=/etc/etcd-certs/ca.crt
+                - --cert=/etc/etcd-certs/client.crt
+                - --key=/etc/etcd-certs/client.key
+                - --dial-timeout=15s
+                # microSD 上での defrag は時間がかかるため長めに取る。
+                - --command-timeout=600s
+                - defrag
+                - --cluster
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 256Mi
+              volumeMounts: *etcdCertMounts
+          # /etc/kubernetes/pki/etcd をディレクトリごと渡すと server.key / peer.key / ca.key まで
+          # 見えてしまうため、必要な 3 ファイルだけを個別に read-only で渡す。
+          volumes:
+            - name: etcd-ca
+              hostPath:
+                path: /etc/kubernetes/pki/etcd/ca.crt
+                type: File
+            - name: etcd-client-cert
+              hostPath:
+                path: /etc/kubernetes/pki/etcd/healthcheck-client.crt
+                type: File
+            - name: etcd-client-key
+              hostPath:
+                path: /etc/kubernetes/pki/etcd/healthcheck-client.key
+                type: File

--- a/argoproj/etcd-defrag/kustomization.yaml
+++ b/argoproj/etcd-defrag/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cronjob.yaml

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - codex-workspace/application.yaml
 - descheduler/application.yaml
 - external-secrets-operator/application.yaml
+- etcd-defrag/application.yaml
 - etcd-snapshot-store/application.yaml
 - even-g2-lab/application.yaml
 - hitohub/overlays/prod/application.yaml

--- a/docs/project_docs/shanghai-node-resilience/plan.md
+++ b/docs/project_docs/shanghai-node-resilience/plan.md
@@ -1,0 +1,97 @@
+# etcd の書き込み churn 削減 (shanghai ノード突然死対策の D)
+
+`boxp/arch` 側の PR と対になる変更。背景の完全版は
+`boxp/arch` の `docs/project_docs/shanghai-node-resilience/plan.md` にある。
+
+## 背景 (要約)
+
+2026-08-01 20:50:45 UTC、control-plane ノード `shanghai-1`
+(192.168.10.102 / Orange Pi Zero 3、rootfs = microSD) が突然ハングし、
+**3日間** 無応答のままだった。電源は入っていたが同一 L2 から ARP INCOMPLETE。
+
+Prometheus (31日保持) で追跡した結果、OOM・温度・ディスク残量・NIC エラーはすべて正常で、
+停止直前まで全指標がフラットだった。真因は **microSD の I/O 破綻によるハードハング**:
+
+| 日付 | shanghai-1 | shanghai-2 | shanghai-3 |
+|---|---|---|---|
+| 07/20 | 5.0 ms | 2.8 ms | 2.3 ms |
+| **08/01 (死亡日)** | **9.5 ms** | 5.4 ms | 2.3 ms |
+
+(write await = `node_disk_write_time_seconds_total / node_disk_writes_completed_total`, device=mmcblk0)
+
+3ノードとも書き込み量は同一 (**~64 GiB/日**) なのに shanghai-1 の write await だけが劣化していた。
+書き込みの主犯は **etcd** で、実測 13.8 MB/60s のユーザ空間書き込みが、
+fsync と SD の消去ブロック粒度でブロック層 64 GiB/日 に増幅されている。
+
+同じ死に方の証拠が shanghai-2 の 2026-08-03 00:13 の journal に残っている
+(journald の書き込みが2分遅延 → `systemd-journald.service: Watchdog timeout (limit 3min)!`
+→ CRI-O `DeadlineExceeded` → ログが途切れて凍結)。
+
+## 本リポジトリでの対応 (D1 / D2)
+
+### D1. etcd defrag の定期自動化 — `argoproj/etcd-defrag/`
+
+2026-08-04 時点で etcd の DB は **626 MB のうち 94% が未使用**。
+肥大した DB はページキャッシュを圧迫し、書き込み増幅を押し上げる。
+
+毎週日曜 04:00 JST に `etcdctl defrag --cluster` を実行する CronJob を追加する。
+
+実装上の制約と対処:
+
+- **etcd イメージ (`registry.k8s.io/etcd:3.6.8-0`) は distroless でシェルを持たない。**
+  実機で `sh` の不在を確認済み。よってシェルスクリプトによる逐次処理と健全性チェックは書けない。
+  代わりに **initContainer を健全性ゲート**として使い、
+  `etcdctl endpoint health --cluster` が失敗したら defrag を実行しない構成にした。
+  既に 1 台落ちている状態で defrag を走らせると quorum を失うため、このゲートは必須。
+- **`etcdctl defrag --cluster` はメンバーを 1 台ずつ順番に処理し、各メンバーの完了を待つ。**
+  同時にブロックされるのは常に 1 台なので、3 メンバー構成では quorum が維持される。
+- **既定の `--command-timeout=5s` では足りない。** Orange Pi Zero 3 上では
+  MemberList だけで DeadlineExceeded になることを実機で確認したため、
+  `--dial-timeout=15s` / health は 60s / defrag は 600s とした。
+- 証明書は `healthcheck-client.crt` を使用 (実機で疎通確認済み)。
+  秘密鍵が root:root 0600 のため `runAsUser: 0`。
+  `/etc/kubernetes/pki/etcd` をディレクトリごと渡すと `server.key` / `peer.key` /
+  (存在すれば) `ca.key` まで見えてしまうため、**必要な 3 ファイルだけ**を
+  個別の read-only hostPath (`type: File`) で渡す。
+- イメージは **manifest list digest で固定**
+  (`registry.k8s.io/etcd:3.6.8-0@sha256:39718941...`)。
+  etcd の秘密鍵を root で読むワークロードなので、キャッシュのないノードへ再スケジュールされた際に
+  レビュー済みと異なるイメージを引かないようにする。
+  `argoproj/argocd-image-updater/imageupdaters/README.md` の第三者イメージ方針に従う。
+  multi-arch の manifest list なので control-plane の arm64 でも解決される。
+- `hostNetwork: true` で `127.0.0.1:2379` を叩き、CNI に依存しない。
+- `ttlSecondsAfterFinished: 86400` — 完了 Job を残し続けると、
+  削減したいはずの etcd 書き込みを自分で増やしてしまう。
+
+### D2. descheduler の実行間隔 — `argoproj/descheduler/helm/values.yaml`
+
+`*/2 * * * *` (720回/日) → `*/30 * * * *` (48回/日)。
+
+1回ごとに Job/Pod オブジェクトの生成・更新・削除が etcd に書かれる。
+2分間隔で回し続ける価値は、microSD 上の control-plane では割に合わない。
+
+## 対で入る変更 (boxp/arch 側)
+
+- **A.** systemd hardware watchdog (`RuntimeWatchdogSec=30`) + `kernel.hung_task_panic=1`
+  (`hung_task_timeout_secs=300`)。3日間の無応答を数分に縮める
+- **B.** `armbian-ramlog` の無効化。`/var/log` が zram (RAM) 上にあったため、
+  導入済みの `journald_persistent_storage` が実際には永続化されておらず、
+  ハング時のログが毎回全消失していた
+- **D3.** 稼働中の `/etc/kubernetes/manifests/etcd.yaml` へ `--listen-metrics-urls` を追加。
+  PR #319 の `monitoring/etcd` ServiceMonitor は 3 ノードとも
+  `2381: connection refused` で **scrape に失敗し続けていた**
+
+## 検証項目
+
+- [ ] `kubectl -n kube-system get cronjob etcd-defrag` が作成される
+- [ ] 手動実行 (`kubectl -n kube-system create job --from=cronjob/etcd-defrag etcd-defrag-manual`) が成功する
+- [ ] 実行後 `etcdctl endpoint status --cluster` の DB SIZE が 626MB から大幅に縮む
+- [ ] 実行中も `endpoint health --cluster` が 3/3 healthy を維持する
+- [ ] descheduler の CronJob schedule が `*/30 * * * *` になる
+
+## 残課題
+
+- **C. etcd を microSD から外す (USB SSD)** — 本命の恒久対策。別途
+- 2026-07-25 19:00 UTC に書き込みが 27 → 64 GiB/日 へ倍増した原因。
+  3ノード同時・同幅だったため etcd 起因なのは確実だが、
+  etcd メトリクスが未収集で犯人を特定できていない。D3 適用後に再調査する


### PR DESCRIPTION
## 背景

boxp/arch の shanghai ノード突然死対策と対になる変更 (D1 / D2)。背景の完全版は `docs/project_docs/shanghai-node-resilience/plan.md` にある。

2026-08-01 20:50:45 UTC、control-plane ノード `shanghai-1` (Orange Pi Zero 3、rootfs = microSD) が突然ハングし、**3日間** 無応答のままだった。Prometheus (31日保持) で追跡した結果、OOM・温度・ディスク残量・NIC エラーはすべて正常で、真因は **microSD の I/O 破綻**だった。

3ノードとも **~64 GiB/日** を microSD に書いており、書き込みの主犯は **etcd** (実測 13.8 MB/60s のユーザ空間書き込みが、fsync と SD の消去ブロック粒度でブロック層 64 GiB/日 に増幅)。

## 変更内容

### D1. etcd defrag の定期自動化 — `argoproj/etcd-defrag/`

2026-08-04 時点で etcd の DB は **626 MB のうち 94% が未使用**だった。肥大した DB はページキャッシュを圧迫し、書き込み増幅を押し上げる。毎週日曜 04:00 JST に `etcdctl defrag --cluster` を実行する CronJob を追加する。

**実機調査を踏まえた実装上の判断:**

- **etcd イメージ (`registry.k8s.io/etcd:3.6.8-0`) は distroless でシェルを持たない** (実機で `sh` の不在を確認)。よってシェルスクリプトによる逐次処理・健全性チェックが書けない。代わりに **initContainer を健全性ゲート**として使い、`etcdctl endpoint health --cluster` が失敗したら defrag を実行しない構成にした。既に1台落ちている状態で defrag すると quorum を失うため、このゲートは必須。
- `etcdctl defrag --cluster` はメンバーを **1台ずつ順に処理し、各メンバーの完了を待つ**。同時にブロックされるのは常に1台なので、3メンバー構成では quorum が維持される。
- **既定の `--command-timeout=5s` では足りない。** Orange Pi Zero 3 上では MemberList だけで `DeadlineExceeded` になることを実機で確認したため、`--dial-timeout=15s` / health 60s / defrag 600s とした。
- `ttlSecondsAfterFinished: 86400` — 完了 Job を残し続けると、削減したいはずの etcd 書き込みを自分で増やしてしまう。

**秘密鍵を扱うワークロードとしての配慮:**

- イメージは **multi-arch manifest list の digest で固定**。`argoproj/argocd-image-updater/imageupdaters/README.md` の第三者イメージ方針に従う。キャッシュのないノードへ再スケジュールされた際にレビュー済みと異なるイメージを引かないようにする。
- `/etc/kubernetes/pki/etcd` をディレクトリごと渡すと `server.key` / `peer.key` / `ca.key` まで露出するため、**必要な3ファイルだけ** (`ca.crt` / `healthcheck-client.crt` / `healthcheck-client.key`) を個別の read-only hostPath (`type: File`) で渡す。

### D2. descheduler の実行間隔 — `argoproj/descheduler/helm/values.yaml`

`*/2 * * * *` (720回/日) → `*/30 * * * *` (48回/日)。1回ごとに Job/Pod オブジェクトの生成・更新・削除が etcd に書かれる。2分間隔で回し続ける価値は、microSD 上の control-plane では割に合わない。

## テスト

手動で同じコマンド列を実機実行済み (leader を最後に、非leader から1台ずつ):

| | 実行前 | 実行後 |
|---|---|---|
| DB SIZE | 626 MB (94% 未使用) | **35 MB** |
| health 応答 | 168〜336 ms | 63〜129 ms |

各メンバー 3.5〜6.5 秒で完了し、実行中も `endpoint health --cluster` は常時 3/3 healthy を維持した。

`kubectl kustomize argoproj/etcd-defrag` および `kubectl kustomize argoproj` の build が通ることを確認済み。

## 関連

- 対になる変更: boxp/arch#11944
  - A: systemd hardware watchdog + `kernel.hung_task_panic`
  - B: `armbian-ramlog` の無効化 (`/var/log` が zram 上にあり、ハング時のログが毎回全消失していた)
  - D3: 稼働中の `/etc/kubernetes/manifests/etcd.yaml` へ `--listen-metrics-urls` を追加。#319 の ServiceMonitor は3ノードとも `2381: connection refused` で **scrape に失敗し続けていた**
- 残課題: **C. etcd を microSD から外す (USB SSD)** — 本命の恒久対策。別 PR
- 2026-07-25 19:00 UTC の書き込み倍増 (27 → 64 GiB/日) の犯人特定は、D3 適用後に再調査する
