### PR TITLE
feat(monitoring): critical アラートを Resend 経由でメール通知する

### DIFF
--- a/argoproj/prometheus-operator/external-secret-alertmanager.yaml
+++ b/argoproj/prometheus-operator/external-secret-alertmanager.yaml
@@ -1,0 +1,117 @@
+# Alertmanager の設定を丸ごと生成する ExternalSecret。
+#
+# 2026-08-01 に shanghai-1 がハングした際、ControlPlaneNodeNotReady (critical) は
+# 死亡の約10分後に発火し3日間鳴り続けていたが、kube-prometheus 既定の receiver は
+# すべて「名前だけ」で通知設定を持たず、Alertmanager が黙って捨てていた。
+# その結果ノードが3日間止まったままになった。
+#
+# API キーと宛先/送信元アドレスを public リポジトリに置かないため、設定本体を
+# template として持ち、値は AWS SSM から注入する。
+# SSM パラメータの定義: boxp/arch の terraform/aws/alertmanager/ssm.tf
+#
+# Alertmanager CR 側は spec.configSecret でこの Secret を参照する
+# (overlays/alertmanager.yaml)。
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-config
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: alertmanager-main-config
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        # kube-prometheus 既定の inhibit_rules / route を踏襲し、
+        # Critical receiver にだけ email_configs を足している。
+        # ルートは既に severity=critical -> Critical が定義済みなので、
+        # 通知対象は critical のみになる。
+        alertmanager.yaml: |
+          global:
+            resolve_timeout: 5m
+            # Resend の SMTP。ユーザ名は固定文字列 "resend"、パスワードが API キー。
+            smtp_smarthost: 'smtp.resend.com:587'
+            smtp_from: '{{ .alert_email_from }}'
+            smtp_auth_username: 'resend'
+            smtp_auth_password: '{{ .resend_api_key }}'
+            smtp_require_tls: true
+
+          inhibit_rules:
+            - source_matchers:
+                - 'severity = critical'
+              target_matchers:
+                - 'severity =~ warning|info'
+              equal:
+                - 'namespace'
+                - 'alertname'
+            - source_matchers:
+                - 'severity = warning'
+              target_matchers:
+                - 'severity = info'
+              equal:
+                - 'namespace'
+                - 'alertname'
+            - source_matchers:
+                - 'alertname = InfoInhibitor'
+              target_matchers:
+                - 'severity = info'
+              equal:
+                - 'namespace'
+
+          route:
+            group_by: ['namespace']
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 12h
+            receiver: 'Default'
+            routes:
+              - matchers:
+                  - 'alertname = Watchdog'
+                receiver: 'Watchdog'
+              - matchers:
+                  - 'alertname = InfoInhibitor'
+                receiver: 'null'
+              - matchers:
+                  - 'severity = critical'
+                receiver: 'Critical'
+                # ノードが落ちている間ずっと届き続けると無視するようになるため、
+                # 再通知は 12h ではなく 6h にして「まだ直っていない」ことだけ伝える。
+                repeat_interval: 6h
+
+          receivers:
+            - name: 'Default'
+            - name: 'Watchdog'
+            - name: 'null'
+            - name: 'Critical'
+              email_configs:
+                # 件名は Alertmanager 既定のテンプレートに任せる。
+                # ここで独自 subject を書くと ESO(Go template) と Alertmanager(Go template) の
+                # {{ }} が二重になり、エスケープを間違えても静かに壊れるだけなので避ける。
+                # 既定でも "[FIRING:1] ControlPlaneNodeNotReady ..." の形で十分判別できる。
+                - to: '{{ .alert_email_to }}'
+                  send_resolved: true
+  data:
+    - secretKey: resend_api_key
+      remoteRef:
+        key: /lolice/alertmanager/RESEND_API_KEY
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: alert_email_to
+      remoteRef:
+        key: /lolice/alertmanager/ALERT_EMAIL_TO
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: alert_email_from
+      remoteRef:
+        key: /lolice/alertmanager/ALERT_EMAIL_FROM
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - application.yaml
 - grafana-lb.yaml
 - external-secret.yaml
+- external-secret-alertmanager.yaml
 - cloudflared-deployment.yaml
 - grafana-pvc.yaml
 - scrape-config.yaml

--- a/argoproj/prometheus-operator/overlays/alertmanager.yaml
+++ b/argoproj/prometheus-operator/overlays/alertmanager.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  # 設定本体は ExternalSecret が SSM から生成する (external-secret-alertmanager.yaml)。
+  # kube-prometheus 既定の alertmanager-main は receiver がすべて空で、
+  # critical アラートが発火しても誰にも届かなかった (2026-08-01 の shanghai-1 の3日間停止)。
+  configSecret: alertmanager-main-config
   tolerations:
     - key: lolice.io/gpu-worker
       operator: Equal

--- a/docs/project_docs/alertmanager-email-notifications/plan.md
+++ b/docs/project_docs/alertmanager-email-notifications/plan.md
@@ -1,0 +1,128 @@
+# Alertmanager のメール通知 (Resend 経由)
+
+## 背景
+
+2026-08-01 20:50:45 UTC に control-plane ノード `shanghai-1` が microSD の I/O 破綻で
+ハングし、**3日間** 無応答のままだった。詳細は
+boxp/arch の `docs/project_docs/shanghai-node-resilience/plan.md`。
+
+### 3日間気づかなかった理由: 通知経路が存在しなかった
+
+アラートルールは存在し、**実際に発火していた**:
+
+| アラート | severity | 発火 |
+|---|---|---|
+| `ControlPlaneNodeNotReady` | critical | 2026-08-01 21:00 UTC（死亡の約10分後） |
+| `KubeNodeNotReady` | warning | 21:30 UTC |
+| `KubeNodeUnreachable` | warning | 21:30 UTC |
+| `KubeletInstanceUnreachable` | warning | 21:30 UTC |
+
+いずれも復旧させるまで3日間鳴り続けていた。しかし Alertmanager の実稼働設定
+(`alertmanager-main-generated`) は kube-prometheus 既定のままで、
+
+```yaml
+receivers:
+- name: Default
+- name: Watchdog
+- name: Critical
+- name: "null"
+```
+
+と **すべて名前だけで通知設定を持たない**。Alertmanager が黙って捨てていた。
+**監視は正常に動作していたが、通知経路が存在しなかった。**
+
+### なぜこれが最優先か
+
+本命の恒久対策である「etcd を microSD から外す (USB SSD)」は
+**ハードウェア制約により対応不可**と判断された (2026-08-05)。
+したがって ~64 GiB/日 を microSD に書き続ける構造は変わらず、
+**ノードは今後も同じ壊れ方をする。**
+
+変えられるのは「10分で気づいて自動復帰するか、3日止まるか」であり、
+
+- 自動復帰 → watchdog + hung_task_panic (boxp/arch#11944 / #11945 で対応済み)
+- 気づく   → **本件**
+
+の2つが実質的な対策になる。
+
+## 方針
+
+送信基盤は **Resend** を使う。`terraform/cloudflare/b0xp.io/lolice-member-portal`
+で既に利用実績があり、新しい送信経路を増やさずに済む。
+
+Resend は SMTP インターフェースを提供しているため、Alertmanager の `email_configs`
+からそのまま利用できる。
+
+| 項目 | 値 |
+|---|---|
+| smarthost | `smtp.resend.com:587` (STARTTLS) |
+| auth_username | `resend` (固定文字列) |
+| auth_password | Resend の API キー |
+| from | Resend で**検証済みドメイン**のアドレスであること |
+
+通知対象は **critical のみ**。kube-prometheus 既定のルートに
+`severity = critical -> Critical` が既にあるため、`Critical` receiver に
+`email_configs` を足すだけで済む。warning まで広げるとノイズで無視するようになるため、
+まず確実に届く状態を作ることを優先する。
+
+## 対になる変更 (boxp/arch)
+
+`terraform/aws/alertmanager/` を新設し、SSM パラメータを3つ定義する。
+
+| パラメータ | 用途 |
+|---|---|
+| `/lolice/alertmanager/RESEND_API_KEY` | SMTP パスワード |
+| `/lolice/alertmanager/ALERT_EMAIL_TO` | 通知先 |
+| `/lolice/alertmanager/ALERT_EMAIL_FROM` | 送信元 (Resend 検証済みドメイン) |
+
+いずれも `SecureString` + ダミー値 + `lifecycle { ignore_changes = [value] }`。
+実値は手動更新する (`terraform/aws/ark-discord-bot/ssm.tf` と同じ方式)。
+
+**通知先アドレスと送信元アドレスも SSM 経由にしている。** public リポジトリに
+個人のメールアドレスを置かないため。
+
+## 変更内容 (本リポジトリ)
+
+- `argoproj/prometheus-operator/external-secret-alertmanager.yaml` (新規)
+  ExternalSecret が SSM から値を取り、`alertmanager.yaml` を丸ごと生成する
+- `argoproj/prometheus-operator/overlays/alertmanager.yaml`
+  Alertmanager CR に `configSecret: alertmanager-main-config` を追加
+
+設定本体を ExternalSecret の `target.template` に置くことで、
+git 上には秘密情報もメールアドレスも残らない。
+
+## 適用順序
+
+**この順でないと動かない。**
+
+1. 本 PR をマージ → `terraform/aws/alertmanager` が apply され、SSM パラメータが
+   ダミー値で作成される
+2. **3つのパラメータに実値を手動で設定する** (AWS コンソールまたは CLI)
+   ```bash
+   aws ssm put-parameter --overwrite --type SecureString \
+     --name /lolice/alertmanager/RESEND_API_KEY   --value 're_xxxxxxxx'
+   aws ssm put-parameter --overwrite --type SecureString \
+     --name /lolice/alertmanager/ALERT_EMAIL_TO   --value 'you@example.com'
+   aws ssm put-parameter --overwrite --type SecureString \
+     --name /lolice/alertmanager/ALERT_EMAIL_FROM --value 'alertmanager@b0xp.io'
+   ```
+3. boxp/lolice 側の PR をマージ → ArgoCD が同期し、Alertmanager が新しい設定で起動
+
+先に 3 をやると ExternalSecret が同期できず `alertmanager-main-config` が作られないため、
+Alertmanager は既存の設定のまま変わらない (停止はしない)。
+
+## 検証項目
+
+- [ ] `kubectl -n monitoring get externalsecret alertmanager-config` が `SecretSynced`
+- [ ] `kubectl -n monitoring get secret alertmanager-main-config` が存在する
+- [ ] Alertmanager Pod が新しい設定で起動する (`amtool check-config` は事前検証済み)
+- [ ] **テストアラートを発火させ、実際にメールが届くこと**
+- [ ] Alertmanager のログに SMTP エラー (認証失敗 / From ドメイン未検証) が無いこと
+
+最後の2つが本質。設定が入っただけでは「届かないアラート」を作り直すだけになる。
+
+## 残課題
+
+- 高耐久 microSD への交換 (shanghai-1 のカードは write await が兄弟機の4倍まで劣化)
+- 2026-07-25 19:00 UTC の書き込み倍増 (27→64 GiB/日) の犯人特定。
+  etcd メトリクスが取れるようになったので追跡可能


### PR DESCRIPTION
## 背景

2026-08-01 に control-plane ノード `shanghai-1` が microSD の I/O 破綻でハングし、**3日間** 無応答のままでした。

**3日間気づかなかったのは、監視が動いていなかったからではありません。アラートは鳴っていました。**

`ControlPlaneNodeNotReady`（severity=critical）が **死亡の約10分後**に発火し、復旧させるまで3日間鳴り続けていました。しかし Alertmanager の実稼働設定は kube-prometheus 既定のままで、

```yaml
receivers:
- name: Default
- name: Watchdog
- name: Critical
- name: "null"
```

と **すべて名前だけで通知設定を持たず**、Alertmanager が黙って捨てていました。

本命の恒久対策である「etcd を microSD から外す（USB SSD）」は **ハードウェア制約により対応不可**と判断されました。ノードは今後も同じ壊れ方をするため、通知経路の復旧が実質的な対策になります。

## 変更内容

### `external-secret-alertmanager.yaml`（新規）

ExternalSecret が SSM から値を取り、`alertmanager.yaml` を丸ごと生成します。設定本体を `target.template` に置くことで、**git 上には API キーもメールアドレスも残りません**。

参照する SSM パラメータは boxp/arch#11946 で定義しています。

### `overlays/alertmanager.yaml`

Alertmanager CR に `configSecret: alertmanager-main-config` を追加します。

## 設計上の判断

**通知対象は critical のみ。** 既定のルートに `severity = critical → Critical` が既にあるため、`Critical` receiver に `email_configs` を足すだけで済みます。warning まで広げるとノイズで無視するようになるため、まず確実に届く状態を作ることを優先しました。

**`repeat_interval` は critical だけ 12h → 6h。** ノード停止中に届き続けると無視の原因になる一方、まったく再通知がないと復旧を忘れるため、中間を取りました。

**件名は Alertmanager 既定のテンプレートに任せています。** 独自 subject を書くと ESO（Go template）と Alertmanager（Go template）の `{{ }}` が二重になり、エスケープを間違えても静かに壊れるだけなので避けました。既定でも `[FIRING:1] ControlPlaneNodeNotReady ...` の形で十分判別できます。

## テスト

生成される `alertmanager.yaml` を **実機の Alertmanager v0.33.0 の `amtool`** で検証済みです。

```
Checking '/alertmanager/amcheck.yaml'  SUCCESS
Found:
 - global config
 - route
 - 3 inhibit rules
 - 4 receivers
 - 0 templates
```

`kubectl kustomize argoproj/prometheus-operator` の build も確認済みです。

## 適用順序

**boxp/arch#11946 を先にマージし、SSM パラメータに実値を設定してから**本 PR をマージしてください。

逆順だと ExternalSecret が同期できず設定が反映されません（Alertmanager 自体は既存設定のまま動き続けるので停止はしません）。

詳細は `docs/project_docs/alertmanager-email-notifications/plan.md` を参照してください。

## 適用後に必ず確認すること

- [ ] `kubectl -n monitoring get externalsecret alertmanager-config` が `SecretSynced`
- [ ] `kubectl -n monitoring get secret alertmanager-main-config` が存在する
- [ ] **テストアラートを発火させ、実際にメールが届くこと**
- [ ] Alertmanager のログに SMTP エラー（認証失敗 / From ドメイン未検証）が無いこと

最後の2つが本質です。設定が入っただけでは「届かないアラート」を作り直すだけになります。特に `ALERT_EMAIL_FROM` は **Resend で検証済みのドメイン**である必要があります。

## 関連

- boxp/arch#11946（対になる SSM パラメータ）
- boxp/arch#11944 / #11945（watchdog による自動復旧・ログ永続化）
