### PR TITLE
fix(monitoring): コメント中の波括弧で Alertmanager 設定の同期が失敗する

### DIFF
--- a/argoproj/prometheus-operator/external-secret-alertmanager.yaml
+++ b/argoproj/prometheus-operator/external-secret-alertmanager.yaml
@@ -91,9 +91,14 @@ spec:
             - name: 'Critical'
               email_configs:
                 # 件名は Alertmanager 既定のテンプレートに任せる。
-                # ここで独自 subject を書くと ESO(Go template) と Alertmanager(Go template) の
-                # {{ }} が二重になり、エスケープを間違えても静かに壊れるだけなので避ける。
+                # ここで独自 subject を書くと ESO と Alertmanager の Go template が
+                # 二重になり、エスケープを間違えても静かに壊れるだけなので避ける。
                 # 既定でも "[FIRING:1] ControlPlaneNodeNotReady ..." の形で十分判別できる。
+                #
+                # 注意: この alertmanager.yaml はブロックスカラーなので、ここの # 行も
+                # 文字列の一部として ESO の Go template に渡る。コメントであっても
+                # 二重波括弧を書くと空アクションとして実行され、
+                # "missing value for command" で同期が丸ごと失敗する (実際に踏んだ)。
                 - to: '{{ .alert_email_to }}'
                   send_resolved: true
   data:

--- a/docs/project_docs/alertmanager-email-notifications/plan.md
+++ b/docs/project_docs/alertmanager-email-notifications/plan.md
@@ -121,6 +121,38 @@ Alertmanager は既存の設定のまま変わらない (停止はしない)。
 
 最後の2つが本質。設定が入っただけでは「届かないアラート」を作り直すだけになる。
 
+## 適用時に踏んだ罠 (2026-08-05)
+
+SSM に実値を設定し #763 をマージしたところ、ExternalSecret が
+`SecretSyncedError` になり Secret が作られなかった。
+
+```
+could not apply template: ... unable to parse template at key alertmanager.yaml:
+template: alertmanager.yaml:60: missing value for command
+```
+
+**原因: コメント行に書いた二重波括弧。**
+`alertmanager.yaml` はブロックスカラー (`|`) なので、`#` で始まる行も
+YAML のコメントではなく**文字列の一部**として ESO の Go template に渡る。
+そこに空の波括弧があると「空アクション」として実行され、テンプレート全体が
+parse に失敗する。皮肉なことに、テンプレートのエスケープに注意しろという
+コメント自体がテンプレートを壊していた。
+
+Alertmanager は既存設定のまま動き続けたので停止はしていない (設計どおり)。
+
+### 再発防止
+
+`scripts/verify-alertmanager-template.py` を追加した。
+テンプレート中の波括弧アクションを列挙し、
+
+- `{{ .foo }}` の形以外が含まれていないか
+- 使われている変数が `spec.data` に定義されているか
+- 展開後に波括弧が残っていないか
+- 展開後が妥当な YAML か
+
+を検証する。**YAML として parse するだけでは足りない**というのが今回の教訓で、
+実際に修正前のファイルに対して FAIL することを確認済み。
+
 ## 残課題
 
 - 高耐久 microSD への交換 (shanghai-1 のカードは write await が兄弟機の4倍まで劣化)

--- a/scripts/verify-alertmanager-template.py
+++ b/scripts/verify-alertmanager-template.py
@@ -1,0 +1,43 @@
+"""ESO の target.template を Go template として妥当か検証する。
+YAML として parse するだけでは、コメント中の {{ }} のような
+「意図しないテンプレートアクション」を見逃す (実際に踏んだ)。"""
+import sys, re, yaml, pathlib
+
+path = sys.argv[1]
+expected = set(sys.argv[2:])
+d = yaml.safe_load(pathlib.Path(path).read_text())
+tpl = d["spec"]["target"]["template"]["data"]["alertmanager.yaml"]
+provided = {x["secretKey"] for x in d["spec"]["data"]}
+
+ok = True
+actions = [(i, m.group(0)) for i, l in enumerate(tpl.splitlines(), 1)
+           for m in re.finditer(r"\{\{.*?\}\}", l)]
+print("テンプレートアクション:")
+for ln, a in actions:
+    key = re.fullmatch(r"\{\{\s*\.(\w+)\s*\}\}", a)
+    if not key:
+        print("  %3d: %-28r  ← 想定外のアクション" % (ln, a)); ok = False
+    elif key.group(1) not in provided:
+        print("  %3d: %-28r  ← spec.data に %s が無い" % (ln, a, key.group(1))); ok = False
+    else:
+        print("  %3d: %-28r  OK" % (ln, a))
+
+missing = expected - {re.fullmatch(r"\{\{\s*\.(\w+)\s*\}\}", a).group(1)
+                      for _, a in actions if re.fullmatch(r"\{\{\s*\.(\w+)\s*\}\}", a)}
+if missing:
+    print("必須プレースホルダが未使用:", missing); ok = False
+
+rendered = tpl
+for k in provided:
+    rendered = rendered.replace("{{ .%s }}" % k, "dummy-%s" % k)
+if "{{" in rendered or "}}" in rendered:
+    print("展開後に波括弧が残っている"); ok = False
+try:
+    cfg = yaml.safe_load(rendered)
+    print("展開後 YAML: OK / receivers =", [r["name"] for r in cfg["receivers"]])
+except Exception as e:
+    print("展開後 YAML が不正:", e); ok = False
+
+pathlib.Path("/tmp/claude-1000/-home-boxp/4861e90a-59a1-45dd-a94f-8c83bc789901/scratchpad/am-rendered2.yaml").write_text(rendered)
+print("\n結果:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## 何が起きたか

#763 をマージし SSM に実値を設定したところ、ExternalSecret が同期に失敗しました。

```
could not apply template: ... unable to parse template at key alertmanager.yaml:
template: alertmanager.yaml:60: missing value for command
```

`alertmanager-main-config` が作られず、Alertmanager の設定は変わらないままです。

**Alertmanager 自体は既存設定のまま動き続けているので停止はしていません**（PR #763 の説明どおりの挙動です）。ただしメール通知は当然まだ届きません。

## 真因

**コメント行に書いた二重波括弧です。**

```yaml
alertmanager.yaml: |
  ...
  # ここで独自 subject を書くと ESO(Go template) と Alertmanager(Go template) の
  # {{ }} が二重になり、エスケープを間違えても静かに壊れるだけなので避ける   ← これ
```

`alertmanager.yaml` はブロックスカラー（`|`）なので、`#` で始まる行も YAML のコメントではなく **文字列の一部**として ESO の Go template に渡ります。そこに空の波括弧があると「空アクション」として実行され、テンプレート全体が parse に失敗します。

テンプレートのエスケープに注意しろというコメント自体がテンプレートを壊していました。

## 修正

コメントから波括弧を除き、この落とし穴を説明する注記に置き換えました。

## 再発防止

`scripts/verify-alertmanager-template.py` を追加しました。

- `{{ .foo }}` の形以外のテンプレートアクションが含まれていないか
- 使われている変数が `spec.data` に定義されているか
- 展開後に波括弧が残っていないか
- 展開後が妥当な YAML か

を検証します。

前回の検証は「既知のプレースホルダをダミー値に置換して YAML として parse する」までで、**意図しないテンプレートアクションを見逃していました**。今回のスクリプトが修正前のファイルに対して実際に FAIL することを確認済みです。

```
$ python3 scripts/verify-alertmanager-template.py <修正前>
  60: '{{ }}'   ← 想定外のアクション
結果: FAIL

$ python3 scripts/verify-alertmanager-template.py <修正後>
   5: '{{ .alert_email_from }}'  OK
   7: '{{ .resend_api_key }}'    OK
  67: '{{ .alert_email_to }}'    OK
展開後 YAML: OK / receivers = ['Default', 'Watchdog', 'null', 'Critical']
結果: PASS
```

`kustomize build` も確認済みです。

## 関連

- #763（本体）
- boxp/arch#11946（SSM パラメータ）
