### PR TITLE
feat(monitoring): control plane のメトリクス公開とメールリンクの修復

### DIFF
--- a/argoproj/prometheus-operator/control-plane-metrics-services.yaml
+++ b/argoproj/prometheus-operator/control-plane-metrics-services.yaml
@@ -1,0 +1,47 @@
+# kube-scheduler / kube-controller-manager を Prometheus から scrape するための Service。
+#
+# kube-prometheus は ServiceMonitor だけを持ち、対応する Service は kubeadm クラスタでは
+# 作られない (selector が app.kubernetes.io/name なのに対し、kubeadm の静的 Pod のラベルは
+# component)。そのため endpoints が空になり、KubeSchedulerDown /
+# KubeControllerManagerDown が恒常的に firing になっていた
+# (実機では 2026-07-04 から1ヶ月鳴りっぱなし)。
+#
+# 併せて boxp/arch 側で --bind-address=0.0.0.0 にしないと届かない
+# (ansible の control_plane_metrics.yml)。両方揃って初めて解消する。
+#
+# ポート名 https-metrics / scheme https は ServiceMonitor の定義に合わせている。
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kube-scheduler
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    component: kube-scheduler
+  ports:
+    - name: https-metrics
+      port: 10259
+      targetPort: 10259
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kube-controller-manager
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    component: kube-controller-manager
+  ports:
+    - name: https-metrics
+      port: 10257
+      targetPort: 10257
+      protocol: TCP

--- a/argoproj/prometheus-operator/kustomization.yaml
+++ b/argoproj/prometheus-operator/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - cloudflared-pod-monitor.yaml
 - etcd-service.yaml
 - etcd-servicemonitor.yaml
+- control-plane-metrics-services.yaml
 - pod-monitor-role.yaml
 - pod-monitor-role-binding.yaml
 - prometheus-servicemonitor-role.yaml
@@ -25,6 +26,7 @@ patchesStrategicMerge:
 - overlays/grafana-datasources.yaml
 - overlays/network-policy-prometheus-k8s.yaml
 - overlays/alertmanager.yaml
+- overlays/network-policy-alertmanager.yaml
 - overlays/prometheus.yaml
 - overlays/grafana.yaml
 - overlays/monitoring-deployment-tolerations.yaml

--- a/argoproj/prometheus-operator/overlays/alertmanager.yaml
+++ b/argoproj/prometheus-operator/overlays/alertmanager.yaml
@@ -9,6 +9,12 @@ spec:
   # kube-prometheus 既定の alertmanager-main は receiver がすべて空で、
   # critical アラートが発火しても誰にも届かなかった (2026-08-01 の shanghai-1 の3日間停止)。
   configSecret: alertmanager-main-config
+  # メール本文の「View in AlertManager」/ silence リンクの宛先。
+  # 未設定だと Alertmanager は Pod のアドレスを使うため、受信したメールの
+  # リンクが全て機能しない (2026-08-05 に実際に発生)。
+  # 公開は boxp/arch の terraform/cloudflare/b0xp.io/prometheus-operator。
+  # Cloudflare Access (GitHub ログイン) で保護している。
+  externalUrl: https://alertmanager.b0xp.io
   tolerations:
     - key: lolice.io/gpu-worker
       operator: Equal

--- a/argoproj/prometheus-operator/overlays/network-policy-alertmanager.yaml
+++ b/argoproj/prometheus-operator/overlays/network-policy-alertmanager.yaml
@@ -1,0 +1,54 @@
+# alertmanager-main の NetworkPolicy に cloudflared からの ingress を追加する。
+#
+# kube-prometheus 既定では Prometheus Pod (9093/8080) と Alertmanager 同士 (9094) しか
+# 許可されていない。alertmanager.b0xp.io を Cloudflare Tunnel で公開しても
+# cloudflared からの接続が弾かれ、メール本文のリンクは開けないままになる。
+# grafana / prometheus-k8s と同じ扱いにする。
+#
+# base の ingress リストは strategic merge では置き換えになるため、
+# 既定の2エントリも明示的に書いている。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-main
+  namespace: monitoring
+spec:
+  egress:
+    - {}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9093
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+    # Cloudflare Tunnel 経由の Web UI アクセス (メール本文のリンク先)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: cloudflared
+      ports:
+        - port: 9093
+          protocol: TCP
+    # Alertmanager 同士のクラスタリング
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+      ports:
+        - port: 9094
+          protocol: TCP
+        - port: 9094
+          protocol: UDP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+    - Egress
+    - Ingress

--- a/argoproj/prometheus-operator/overlays/prometheus.yaml
+++ b/argoproj/prometheus-operator/overlays/prometheus.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: 1
   retention: 31d
+  # アラートメール内の各アラートの Source リンク (generatorURL) の宛先。
+  # 未設定だと Pod のアドレスになりリンクが機能しない。
+  externalUrl: https://prometheus-web.b0xp.io
   tolerations:
     - key: lolice.io/gpu-worker
       operator: Equal

--- a/docs/project_docs/control-plane-metrics-and-alert-links/plan.md
+++ b/docs/project_docs/control-plane-metrics-and-alert-links/plan.md
@@ -1,0 +1,112 @@
+# 通知の実用化: 誤検知の解消とメールリンクの修復
+
+## 背景
+
+`docs/project_docs/alertmanager-email-notifications/plan.md` で
+critical アラートのメール通知が届くようになった。その最初の実運用で2つの問題が出た。
+
+### 1. 最初に届いたのが1ヶ月前からの誤検知だった
+
+```
+KubeSchedulerDown          2026-07-04 00:18:02 UTC から firing
+KubeControllerManagerDown  2026-07-04 00:18:07 UTC から firing
+```
+
+実機を確認したところ、コンポーネント自体は正常だった:
+
+```
+kube-scheduler / kube-controller-manager: --bind-address=127.0.0.1
+listen: 127.0.0.1:10259 / 127.0.0.1:10257   ← ノード外から scrape できない
+$ kubectl get endpoints -n kube-system kube-scheduler
+Error from server (NotFound)
+```
+
+**kubeadm 構成の典型的な誤検知。** Prometheus から届かないだけ。
+これを放置すると 6 時間ごとに誤検知メールが届き、
+「Alertmanager からのメールは無視するもの」になる。せっかく直した通知経路が実質また死ぬ。
+
+原因は2つあり、**両方揃わないと解消しない**:
+
+- kubeadm 既定の `--bind-address=127.0.0.1` でノード外から届かない (本リポジトリ)
+- kube-prometheus は ServiceMonitor しか持たず、対応する Service が無い。
+  ServiceMonitor の selector は `app.kubernetes.io/name` だが、kubeadm の静的 Pod の
+  ラベルは `component` (boxp/lolice 側)
+
+### 2. メール本文のリンクが全て機能しない
+
+Alertmanager と Prometheus の `externalUrl` がどちらも未設定だった。
+未設定だと Pod のアドレス (`http://alertmanager-main-0:9093` 等) が使われるため、
+メールクライアントからは開けない。
+
+- 「View in AlertManager」/ silence リンク → Alertmanager の `externalUrl`
+- 各アラートの Source リンク (generatorURL) → Prometheus の `externalUrl`
+
+Cloudflare トンネルは既に `grafana.b0xp.io` と `prometheus-web.b0xp.io` を公開していたが、
+**Alertmanager は公開されていなかった**。
+
+## 対になる変更 (boxp/arch)
+
+### terraform/cloudflare/b0xp.io/prometheus-operator
+
+`alertmanager.b0xp.io` を既存トンネルに追加する。
+
+| ファイル | 変更 |
+|---|---|
+| `dns.tf` | CNAME レコードを追加 |
+| `tunnel.tf` | ingress に `http://alertmanager-main.monitoring.svc.cluster.local:9093` を追加 |
+| `access.tf` | Access application + policy (GitHub ログイン) を追加 |
+
+**Access による保護は必須。** Alertmanager はサイレンス操作ができ、
+インフラ構成も見えるため、grafana / prometheus-web と同じ扱いにする。
+
+### ansible
+
+`control_plane_metrics.yml` を新設し、kube-scheduler / kube-controller-manager の
+`--bind-address` を `0.0.0.0` にする。
+
+10259/10257 は RBAC 認証付きなので、LAN へ bind しても未認証では読めない。
+
+既定は `false`。control-plane playbook 側で明示的に有効化する
+(`journald_persistent_storage` / `node_resilience_*` と同じ方式)。
+
+静的 Pod ディレクトリ内にバックアップを作らない・変更前の原本を
+`/var/backups/kubernetes-manifests/` へ退避する、という #11944 で確立した方式を踏襲する。
+どちらのコンポーネントもリーダー選出で動くため、変更後は新しいアドレスで
+listen するまで待ってから次のノードへ進む (playbook の `serial: 1` と組み合わせる)。
+
+## 変更内容 (本リポジトリ)
+
+- `control-plane-metrics-services.yaml` (新規) — ServiceMonitor が要求する
+  `app.kubernetes.io/name` ラベルを持ち、静的 Pod の `component` ラベルを selector にする
+  headless Service を kube-system に作る
+- `overlays/alertmanager.yaml` — `externalUrl: https://alertmanager.b0xp.io`
+- `overlays/prometheus.yaml` — `externalUrl: https://prometheus-web.b0xp.io`
+
+## レビューで見つかった「これでは目的を達成できない」2件
+
+### NetworkPolicy が cloudflared を弾く
+
+`alertmanager-main` の NetworkPolicy は kube-prometheus 既定のままで、
+Prometheus Pod (9093/8080) と Alertmanager 同士 (9094) しか許可していない。
+トンネルを通しても cloudflared からの接続が拒否され、**メールのリンクは開けないまま**になる。
+`overlays/network-policy-alertmanager.yaml` で cloudflared からの 9093 を許可する。
+strategic merge では ingress リストが置き換わるため、既定の2エントリも明示的に書いている。
+
+### kubeadm upgrade で bind-address が戻る (boxp/arch 側)
+
+`kubeadm upgrade apply/node` は `--config` なしで実行され、ローカルファイルではなく
+`kube-system/kubeadm-config` の ClusterConfiguration を読む。
+稼働中マニフェストを直すだけでは次回アップグレードで誤検知が再発する。
+
+## 検証項目
+
+- [ ] `terraform validate` (実行済み: Success)
+- [ ] `ansible-lint` (実行済み: pass)
+- [ ] 適用後 `ss -lnt | grep 1025` がノード IP で listen していること
+- [ ] `kubectl get endpoints -n kube-system kube-scheduler` に 3 エンドポイントが出ること
+- [ ] Prometheus の kube-scheduler / kube-controller-manager target が up になること
+- [ ] `KubeSchedulerDown` / `KubeControllerManagerDown` が resolved になること
+- [ ] **メールのリンクを実際にクリックして開けること** (Access のログイン後)
+
+最後の項目が本質。`externalUrl` を入れただけでは、トンネルが通っていなければ
+リンクは開けない。


### PR DESCRIPTION
## 背景

#763 / #764 で critical アラートのメール通知が届くようになりました。その最初の実運用で出た問題を塞ぎます。boxp/arch#11947 と対になる変更です。

## 1. KubeSchedulerDown / KubeControllerManagerDown の誤検知

2026-07-04 から1ヶ月 firing のままでした。コンポーネント自体は正常で、Prometheus から scrape できていないだけです。

kube-prometheus は ServiceMonitor しか持たず、**対応する Service が kubeadm クラスタでは作られません**。ServiceMonitor の selector は `app.kubernetes.io/name` ですが、kubeadm の静的 Pod のラベルは `component` だからです。

```
$ kubectl get endpoints -n kube-system kube-scheduler
Error from server (NotFound)
```

`control-plane-metrics-services.yaml` で、ServiceMonitor が要求するラベルを持ち静的 Pod の `component` を selector にする headless Service を kube-system に作ります。ポート名 `https-metrics` / 10259・10257 は ServiceMonitor の定義に合わせました。selector が実 Pod 3台にヒットすることを実機で確認済みです。

boxp/arch 側で `--bind-address=0.0.0.0` にしないと届かないため、**両方揃って初めて解消します**。

## 2. メール本文のリンクが全て機能しない

`externalUrl` が Alertmanager / Prometheus とも未設定で、Pod のアドレス（`http://alertmanager-main-0:9093` 等）が使われていました。メールクライアントからは開けません。

- 「View in AlertManager」/ silence リンク → Alertmanager の `externalUrl`
- 各アラートの Source リンク（generatorURL）→ Prometheus の `externalUrl`

`alertmanager.b0xp.io` は boxp/arch#11947 で Cloudflare トンネルに追加し、Access（GitHub ログイン）で保護します。

## 3. NetworkPolicy が cloudflared を弾いていた

`alertmanager-main` の NetworkPolicy は kube-prometheus 既定のままで、Prometheus Pod（9093/8080）と Alertmanager 同士（9094）しか許可していませんでした。

**トンネルを通しても cloudflared からの接続が拒否され、メールのリンクは開けないままになります。** `externalUrl` を設定するだけでは目的を達成できません。

`overlays/network-policy-alertmanager.yaml` で cloudflared からの 9093 を許可します。strategic merge では ingress リストが置き換わるため、既定の2エントリも明示的に書いています。

`kustomize build` 後の ingress が3エントリになることを確認済みです。

```
from=[{'app.kubernetes.io/name': 'prometheus'}]   ports=[9093, 8080]
from=[{'app': 'cloudflared'}]                     ports=[9093]
from=[{'app.kubernetes.io/name': 'alertmanager'}] ports=[9094, 9094]
```

## テスト

- `kubectl kustomize argoproj/prometheus-operator`: OK
- Service の selector が実 Pod 3台にヒットすることを実機で確認
- NetworkPolicy のマージ結果を build 後の出力で確認

## 適用後に必ず確認すること

- [ ] `kubectl get endpoints -n kube-system kube-scheduler` に3エンドポイントが出ること
- [ ] Prometheus の kube-scheduler / kube-controller-manager target が up になること
- [ ] `KubeSchedulerDown` / `KubeControllerManagerDown` が resolved になること
- [ ] **メールのリンクを実際にクリックして開けること**（Access のログイン後）

## 関連

- boxp/arch#11947（bind-address・Cloudflare トンネル・kubeadm-config の修正）
- #763 / #764（メール通知の本体と修正）
