### PR TITLE
feat: ark-discord-bot external-secret に GITHUB_TOKEN を追加 (BOXP-138)

### DIFF
--- a/argoproj/ark-discord-bot/external-secret.yaml
+++ b/argoproj/ark-discord-bot/external-secret.yaml
@@ -17,7 +17,10 @@ spec:
       key: /lolice/ark-discord-bot/DISCORD_BOT_TOKEN
   - secretKey: DISCORD_CHANNEL_ID
     remoteRef:
-      key: /lolice/ark-discord-bot/DISCORD_CHANNEL_ID  
+      key: /lolice/ark-discord-bot/DISCORD_CHANNEL_ID
   - secretKey: RCON_PASSWORD
     remoteRef:
       key: /lolice/ark-discord-bot/RCON_PASSWORD
+  - secretKey: GITHUB_TOKEN
+    remoteRef:
+      key: /lolice/ark-discord-bot/GITHUB_TOKEN


### PR DESCRIPTION
## Summary

- `argoproj/ark-discord-bot/external-secret.yaml` に `GITHUB_TOKEN` エントリを追加
- SSM Parameter Store のパス `/lolice/ark-discord-bot/GITHUB_TOKEN` から取得
- `!pal update` コマンドが palserver の `check-palworld-update.yml` を workflow_dispatch するために必要

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `argoproj/ark-discord-bot/external-secret.yaml` | `GITHUB_TOKEN` の ExternalSecret エントリを追加 |

## 前提条件

- [x] SSM Parameter `/lolice/ark-discord-bot/GITHUB_TOKEN` に workflow スコープ付き PAT が設定済み（ユーザー確認済み）
- [x] ark-discord-bot PR#116, #119, #120 がマージ済み

## Test plan

- [ ] ArgoCD が ExternalSecret を同期して `ark-discord-bot-secret` に `GITHUB_TOKEN` が追加されることを確認
- [ ] `!pal update` コマンドが正常に動作することを確認

Closes BOXP-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)